### PR TITLE
fix(plugin): resolve ESM import issues with preset and missing module

### DIFF
--- a/packages/plugin/src/preset.ts
+++ b/packages/plugin/src/preset.ts
@@ -1,6 +1,6 @@
 import { dirname, join, resolve } from "node:path";
 import { createRequire } from "node:module";
-import {fileURLToPath} from 'node:url';
+import { fileURLToPath } from 'node:url';
 import { mergeConfig } from 'vite'
 import stencil from 'unplugin-stencil/vite'
 

--- a/packages/plugin/src/preset.ts
+++ b/packages/plugin/src/preset.ts
@@ -1,5 +1,6 @@
 import { dirname, join, resolve } from "node:path";
 import { createRequire } from "node:module";
+import {fileURLToPath} from 'node:url';
 import { mergeConfig } from 'vite'
 import stencil from 'unplugin-stencil/vite'
 
@@ -8,6 +9,8 @@ import { StorybookConfig } from './types.js'
 const require = createRequire(import.meta.url);
 const getAbsolutePath = <I extends string>(input: I): I =>
   dirname(require.resolve(join(input, 'package.json'))) as any;
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const renderer = join(__dirname, 'preview.js')
 

--- a/packages/plugin/src/render.ts
+++ b/packages/plugin/src/render.ts
@@ -2,7 +2,7 @@ import { ArgsStoryFn, RenderContext } from '@storybook/types'
 import { simulatePageLoad } from '@storybook/preview-api'
 import { render as renderStencil } from '@stencil/core'
 
-import { componentToJSX } from './component-to-jsx'
+import { componentToJSX } from './component-to-jsx.js'
 import type { StencilRenderer } from './types'
 
 export const render: ArgsStoryFn<StencilRenderer<unknown>> = (args, context) => {


### PR DESCRIPTION
## Summary
This PR resolves two issues encountered when integrating `@stencil/storybook-plugin`:

- `SB_CORE-SERVER_0002`: Storybook failed to load the preset due to `__dirname` usage in an ES module context.
- `ERR_MODULE_NOT_FOUND`: Module resolution failed for **component-to-jsx** in **render.js** due to missing `.js` extension in import paths.

### Changes Made
- Replaced `__dirname` with `import.meta.url` and `fileURLToPath()` in **preset.js** to ensure compatibility with ESM.
- Updated import statements to include `.js` extensions

### Testing
- Verified that the Plugin builds without errors.
- Verified that Storybook starts without errors using npm run storybook.
- Confirmed that all components render successfully in the Storybook UI.
- Ensured no broken imports or runtime resolution issues occur.​
- Ensured tests are passing.

