### PR TITLE
fix(types): alias Stencil JSX types before extending to avoid TS2310

### DIFF
--- a/packages/plugin/src/types.ts
+++ b/packages/plugin/src/types.ts
@@ -95,10 +95,13 @@ export type StorybookConfig = Omit<StorybookConfigBase, 'framework'> & {
  * This is necessary to allow the use of Stencil components in Storybook.
  * Without we get are getting type errors.
  */
+type StencilIntrinsic = StencilJSX.IntrinsicElements;
+type StencilElement   = StencilJSX.Element;
+
 declare global {
   namespace JSX {
-    interface IntrinsicElements extends StencilJSX.IntrinsicElements {}
-    interface Element extends StencilJSX.Element {}
+    interface IntrinsicElements extends StencilIntrinsic {}
+    interface Element extends StencilElement {}
     interface ElementClass {}
   }
 }


### PR DESCRIPTION
## Description
After generating a new Stencil project with Storybook and required plugins, the Stencil build fails due to a recursive type reference in the generated `JSX.IntrinsicElements` and `JSX.Element` interfaces.

### Error
```
Type 'IntrinsicElements' recursively references itself as a base type
```

This occurs once Stencil’s generated types are flattened by the compiler

## Workaround
Temporarily set `"skipLibCheck": true` in `tsconfig.json` to bypass `.d.ts` type-checking and allow the build to proceed.

> ⚠️ Note: Some organizations or repos may restrict the use of `skipLibCheck`, so this should be considered a temporary workaround.

### Fix
Consider capturing a snapshot of Stencil’s generated interfaces and extending from aliases instead of live `JSX` types to avoid the self-referencing issue.

## How to reproduce
1. In `packages/example/tsconfig.json`, remove `"skipLibCheck": true`
2. Run `stencil build`