### PR TITLE
chore: add support for rendering slots with fragments

### DIFF
--- a/packages/example/src/components/my-slotted/MySlotted.stories.tsx
+++ b/packages/example/src/components/my-slotted/MySlotted.stories.tsx
@@ -14,22 +14,42 @@ const meta = {
 export default meta;
 type Story = StoryObj<MySlotted>;
 
-export const Primary: Story = {
+export const Strings: Story = {
   args: {},
   parameters: {
     slots: {
-      default: 'Hello World',
+      default: 'default',
+      another: 'another',
+    },
+  },
+};
+
+export const Elements: Story = {
+  args: {},
+  parameters: {
+    slots: {
+      default: <div>default</div>,
       another: <div>another</div>,
     },
   },
 };
 
-export const Secondary: Story = {
+export const Fragments: Story = {
   args: {},
   parameters: {
     slots: {
-      default: <div>default</div>,
-      another: 'does it work?'
+      default: (
+        <>
+          <h1>hello</h1>
+          <h2>world</h2>
+        </>
+      ),
+      another: (
+        <>
+          <h1>hello</h1>
+          <h2>world</h2>
+        </>
+      ),
     },
   },
 };

--- a/packages/example/src/components/my-slotted/my-slotted.spec.ts
+++ b/packages/example/src/components/my-slotted/my-slotted.spec.ts
@@ -11,10 +11,14 @@ describe('my-slotted', () => {
       <my-slotted>
         <mock:shadow-root>
           <div>
-            Hello, World!
+            <slot></slot>
             <hr />
+            <div style="background: pink;">
+              <slot name="another"></slot>
+            </div>
           </div>
         </mock:shadow-root>
+        Hello, World!
       </my-slotted>
     `);
   });
@@ -28,13 +32,15 @@ describe('my-slotted', () => {
       <my-slotted>
         <mock:shadow-root>
           <div>
-            Hello there
+            <slot></slot>
             <hr />
-            <div style={{background: 'pink'}}>
-              <div slot="another">another</div>
+            <div style="background: pink;">
+              <slot name="another"></slot>
             </div>
           </div>
         </mock:shadow-root>
+        Hello there
+        <div slot="another">another</div>
       </my-slotted>
     `);
   });

--- a/packages/plugin/src/render.ts
+++ b/packages/plugin/src/render.ts
@@ -1,8 +1,9 @@
 import { ArgsStoryFn, RenderContext } from 'storybook/internal/types'
 import { simulatePageLoad } from 'storybook/preview-api'
-import { render as renderStencil, h, VNode } from '@stencil/core'
+import { render as renderStencil, h, VNode, Fragment } from '@stencil/core'
 
 import type { StencilRenderer } from './types'
+
 
 export const render: ArgsStoryFn<StencilRenderer<unknown>> = (args, context) => {
     const { component, parameters } = context;
@@ -16,12 +17,12 @@ export const render: ArgsStoryFn<StencilRenderer<unknown>> = (args, context) => 
         throw new Error('Component is not registered!')
     }
 
-    const children: VNode[] = Object.entries<VNode>(parameters.slots || []).map(
+    const children: any[] = Object.entries<VNode>(parameters.slots || []).map(
       ([key, value]) => {
           // if the parameter key is 'default' don't give it a slot name so it renders just as a child
           const slot = key === 'default' ? undefined : key
           // if the value it s a string, create a vnode with the string as the children
-          return typeof value === "string"
+          const child = typeof value === "string"
             ? h(null, { slot }, value)
             : {
                 ...value,
@@ -29,6 +30,9 @@ export const render: ArgsStoryFn<StencilRenderer<unknown>> = (args, context) => 
                   slot,
                 },
               };
+          // if the value is a fragment and it is a named slot, create a span element with the slot name
+          child.$tag$ = child.$tag$ || (slot ? 'span': null);
+          return child.$tag$ ? child : child.$children$
       },
     );
 

--- a/packages/plugin/src/render.ts
+++ b/packages/plugin/src/render.ts
@@ -23,7 +23,7 @@ export const render: ArgsStoryFn<StencilRenderer<unknown>> = (args, context) => 
           const slot = key === 'default' ? undefined : key
           // if the value it s a string, create a vnode with the string as the children
           const child = typeof value === "string"
-            ? h(null, { slot }, value)
+            ? h(undefined, { slot }, value)
             : {
                 ...value,
                 $attrs$: {

--- a/tests/test.e2e.ts
+++ b/tests/test.e2e.ts
@@ -57,16 +57,65 @@ describe('StencilJS Storybook', () => {
         `)
     })
 
-    it('should render the component with slots', async () => {
-        await browser.url(`/?path=/story/myslotted--primary`)
+    it('should render the component with slots as strings', async () => {
+        await browser.url(`/?path=/story/myslotted--strings`)
         await browser.pause(3000)
         await browser.switchFrame(() => Boolean(document.querySelector('my-slotted')))
 
         await expect($('my-slotted')).toBeExisting()
         await expect($('my-slotted')).toMatchInlineSnapshot(`
           "<my-slotted class="hydrated">
-            <null>Hello World</null>
+            "default"
+            <span slot="another">another</div>
+            <template shadowrootmode="open">
+              <style>:host { display: block; }</style>
+              <div>
+                <slot></slot>
+                <hr />
+                <div style="background: pink;">
+                  <slot name="another"></slot>
+                </div>
+              </div>
+            </template>
+          </my-slotted>"
+        `)
+    })
+
+    it('should render the component with slots as elements', async () => {
+        await browser.url(`/?path=/story/myslotted--elements`)
+        await browser.pause(3000)
+        await browser.switchFrame(() => Boolean(document.querySelector('my-slotted')))
+
+        await expect($('my-slotted')).toBeExisting()
+        await expect($('my-slotted')).toMatchInlineSnapshot(`
+          "<my-slotted class="hydrated">
+            <div>Hello World</div>
             <div slot="another">another</div>
+            <template shadowrootmode="open">
+              <style>:host { display: block; }</style>
+              <div>
+                <slot></slot>
+                <hr />
+                <div style="background: pink;">
+                  <slot name="another"></slot>
+                </div>
+              </div>
+            </template>
+          </my-slotted>"
+        `)
+    })
+
+    it('should render the component with slots as fragments', async () => {
+        await browser.url(`/?path=/story/myslotted--fragments`)
+        await browser.pause(3000)
+        await browser.switchFrame(() => Boolean(document.querySelector('my-slotted')))
+
+        await expect($('my-slotted')).toBeExisting()
+        await expect($('my-slotted')).toMatchInlineSnapshot(`
+          "<my-slotted class="hydrated">
+            <h1>hello</h1>
+            <h2>world</h2>
+            <span slot="another">another</span>
             <template shadowrootmode="open">
               <style>:host { display: block; }</style>
               <div>

--- a/tests/test.e2e.ts
+++ b/tests/test.e2e.ts
@@ -65,8 +65,8 @@ describe('StencilJS Storybook', () => {
         await expect($('my-slotted')).toBeExisting()
         await expect($('my-slotted')).toMatchInlineSnapshot(`
           "<my-slotted class="hydrated">
-            "default"
-            <span slot="another">another</div>
+            default
+            <span slot="another">another</span>
             <template shadowrootmode="open">
               <style>:host { display: block; }</style>
               <div>
@@ -89,7 +89,7 @@ describe('StencilJS Storybook', () => {
         await expect($('my-slotted')).toBeExisting()
         await expect($('my-slotted')).toMatchInlineSnapshot(`
           "<my-slotted class="hydrated">
-            <div>Hello World</div>
+            <div>default</div>
             <div slot="another">another</div>
             <template shadowrootmode="open">
               <style>:host { display: block; }</style>
@@ -115,7 +115,10 @@ describe('StencilJS Storybook', () => {
           "<my-slotted class="hydrated">
             <h1>hello</h1>
             <h2>world</h2>
-            <span slot="another">another</span>
+            <span slot="another">
+              <h1>hello</h1>
+              <h2>world</h2>
+            </span>
             <template shadowrootmode="open">
               <style>:host { display: block; }</style>
               <div>

--- a/tests/wdio.conf.ts
+++ b/tests/wdio.conf.ts
@@ -15,7 +15,7 @@ export const config: WebdriverIO.Config = {
     // WebdriverIO supports running e2e tests as well as unit and component tests.
     runner: 'local',
     tsConfigPath: './tsconfig.json',
-    
+
     //
     // ==================
     // Specify Test Files
@@ -66,7 +66,7 @@ export const config: WebdriverIO.Config = {
             args: process.env.CI ? ['--headless'] : []
         }
     }],
-
+    cacheDir: 'node_modules/.cache',
     //
     // ===================
     // Test Configurations
@@ -123,7 +123,7 @@ export const config: WebdriverIO.Config = {
     // Make sure you have the wdio adapter package for the specific framework installed
     // before running any tests.
     framework: 'mocha',
-    
+
     //
     // The number of times to retry the entire specfile when it fails as a whole
     specFileRetries: 1,


### PR DESCRIPTION
When using slots with `h(null` or `h(undefined` it would render `<null>` and `<undefined>` as elements. Instead we want to just render the children when it is a string or when it is using the jsx fragment.

if it is a named slot and that slot uses a fragment, assign it to a span with the slot attr.