### PR TITLE
fix: replace CommonJS export syntax in preset.js with ES6 export syntax

### DIFF
--- a/packages/plugin/preset.js
+++ b/packages/plugin/preset.js
@@ -1,2 +1,2 @@
 // This file seems to only be necessary for Windows
-module.exports = require('./dist/preset.js');
+export * from './dist/preset.js';


### PR DESCRIPTION
I was encountering a

`ReferenceError: module is not defined`

coming from `node_modules/@stencil/storybook-plugin/preset.js:2:1` when running @stencil/storybook-plugin on Windows.

Changing to this syntax in the appropriate node_modules file resolved this issue. Let me know if this is incorrect.