### PR TITLE
fix: exlude event args from source code block

### DIFF
--- a/packages/example-lazy/src/components.d.ts
+++ b/packages/example-lazy/src/components.d.ts
@@ -7,6 +7,8 @@
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 export namespace Components {
     interface MyComponent {
+        "booleanTest": boolean;
+        "complexTest"?: ComplexType;
         /**
           * The first name
          */
@@ -19,6 +21,7 @@ export namespace Components {
           * The middle name
          */
         "middle": string;
+        "numberTest"?: number;
         /**
           * show radio control for < 5 options
          */
@@ -27,12 +30,31 @@ export namespace Components {
           * show select control for >= 5 options
          */
         "selectTest"?: '1' | '2' | '3' | '4' | '5';
+        /**
+          * @default 'hello'
+         */
+        "stringTest"?: string;
     }
     interface MySlotted {
     }
 }
+export interface MyComponentCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLMyComponentElement;
+}
 declare global {
+    interface HTMLMyComponentElementEventMap {
+        "evalEvent": void;
+    }
     interface HTMLMyComponentElement extends Components.MyComponent, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLMyComponentElementEventMap>(type: K, listener: (this: HTMLMyComponentElement, ev: MyComponentCustomEvent<HTMLMyComponentElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLMyComponentElementEventMap>(type: K, listener: (this: HTMLMyComponentElement, ev: MyComponentCustomEvent<HTMLMyComponentElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLMyComponentElement: {
         prototype: HTMLMyComponentElement;
@@ -51,6 +73,8 @@ declare global {
 }
 declare namespace LocalJSX {
     interface MyComponent {
+        "booleanTest"?: boolean;
+        "complexTest"?: ComplexType;
         /**
           * The first name
          */
@@ -63,6 +87,8 @@ declare namespace LocalJSX {
           * The middle name
          */
         "middle"?: string;
+        "numberTest"?: number;
+        "onEvalEvent"?: (event: MyComponentCustomEvent<void>) => void;
         /**
           * show radio control for < 5 options
          */
@@ -71,6 +97,10 @@ declare namespace LocalJSX {
           * show select control for >= 5 options
          */
         "selectTest"?: '1' | '2' | '3' | '4' | '5';
+        /**
+          * @default 'hello'
+         */
+        "stringTest"?: string;
     }
     interface MySlotted {
     }

--- a/packages/example-lazy/src/components/my-component/MyComponent.stories.tsx
+++ b/packages/example-lazy/src/components/my-component/MyComponent.stories.tsx
@@ -1,7 +1,6 @@
 import { h } from '@stencil/core';
 import type { Meta, StoryObj } from '@stencil/storybook-plugin';
-
-import { MyComponent } from './my-component';
+import type { JSX } from '../../components';
 
 const meta = {
   title: 'MyComponent',
@@ -9,16 +8,17 @@ const meta = {
   parameters: {
     layout: 'centered',
   },
-} satisfies Meta<MyComponent>;
+} satisfies Meta<JSX.MyComponent>;
 
 export default meta;
-type Story = StoryObj<MyComponent>;
+type Story = StoryObj<JSX.MyComponent>;
 
 export const Primary: Story = {
   args: {
     first: 'John',
     last: 'Doe',
     middle: 'Michael',
+    onEvalEvent: () => console.log('Eval event triggered'),
   },
   render: props => {
     return <my-component {...props} />;

--- a/packages/example-lazy/src/components/my-component/my-component.tsx
+++ b/packages/example-lazy/src/components/my-component/my-component.tsx
@@ -1,5 +1,7 @@
-import { Component, Prop, h } from '@stencil/core';
+import { Component, Event, EventEmitter, Prop, h } from '@stencil/core';
 import { format } from '../../utils/utils';
+
+type ComplexType = string;
 
 @Component({
   tag: 'my-component',
@@ -27,6 +29,13 @@ export class MyComponent {
 
   /** show select control for >= 5 options */
   @Prop() selectTest?: '1' | '2' | '3' | '4' | '5';
+
+  @Prop() booleanTest: boolean;
+  @Prop() numberTest?: number;
+  @Prop() stringTest?: string = 'hello';
+  @Prop() complexTest?: ComplexType;
+
+  @Event() evalEvent: EventEmitter<void>;
 
   private getText(): string {
     return format(this.first, this.middle, this.last);

--- a/packages/example/src/components.d.ts
+++ b/packages/example/src/components.d.ts
@@ -38,8 +38,23 @@ export namespace Components {
     interface MySlotted {
     }
 }
+export interface MyComponentCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLMyComponentElement;
+}
 declare global {
+    interface HTMLMyComponentElementEventMap {
+        "evalEvent": void;
+    }
     interface HTMLMyComponentElement extends Components.MyComponent, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLMyComponentElementEventMap>(type: K, listener: (this: HTMLMyComponentElement, ev: MyComponentCustomEvent<HTMLMyComponentElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLMyComponentElementEventMap>(type: K, listener: (this: HTMLMyComponentElement, ev: MyComponentCustomEvent<HTMLMyComponentElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLMyComponentElement: {
         prototype: HTMLMyComponentElement;
@@ -73,6 +88,7 @@ declare namespace LocalJSX {
          */
         "middle"?: string;
         "numberTest"?: number;
+        "onEvalEvent"?: (event: MyComponentCustomEvent<void>) => void;
         /**
           * show radio control for < 5 options
          */

--- a/packages/example/src/components/my-component/MyComponent.stories.tsx
+++ b/packages/example/src/components/my-component/MyComponent.stories.tsx
@@ -1,6 +1,6 @@
 import { h } from '@stencil/core';
 import type { Meta, StoryObj } from '@stencil/storybook-plugin';
-
+import type { JSX } from '../../components';
 import { MyComponent } from './my-component';
 
 const meta = {
@@ -9,16 +9,17 @@ const meta = {
   parameters: {
     layout: 'centered',
   },
-} satisfies Meta<MyComponent>;
+} satisfies Meta<JSX.MyComponent>;
 
 export default meta;
-type Story = StoryObj<MyComponent>;
+type Story = StoryObj<JSX.MyComponent>;
 
 export const Primary: Story = {
   args: {
     first: 'John',
     last: 'Doe',
     middle: 'Michael',
+    onEvalEvent: () => console.log('Eval event triggered'),
   },
   render: props => {
     return <my-component {...props} />;

--- a/packages/example/src/components/my-component/my-component.tsx
+++ b/packages/example/src/components/my-component/my-component.tsx
@@ -1,4 +1,4 @@
-import { Component, Prop, h } from '@stencil/core';
+import { Component, Event, EventEmitter, Prop, h } from '@stencil/core';
 import { format } from '../../utils/utils';
 
 type ComplexType = string;
@@ -34,6 +34,8 @@ export class MyComponent {
   @Prop() numberTest?: number;
   @Prop() stringTest?: string = 'hello';
   @Prop() complexTest?: ComplexType;
+
+  @Event() evalEvent: EventEmitter<void>;
 
   private getText(): string {
     return format(this.first, this.middle, this.last);

--- a/packages/plugin/src/docs/render-html.ts
+++ b/packages/plugin/src/docs/render-html.ts
@@ -16,6 +16,10 @@ function vnodeToHtml(node: VNode, indentLevel = 0): string {
     ? Object.entries(node.$attrs$)
         .filter(([_, value]) => value !== undefined)
         .map(([key, value]) => {
+          if (typeof value === 'function') {
+            // hide event handlers from source code
+            return '';
+          }
           if (typeof value === 'boolean') {
             return value ? ` ${key}` : '';
           }


### PR DESCRIPTION
when an event arg was passed as an arg, it would include all of the fn code in the story source code block, resulting in easily copied code and a lot of excess if fn() was passed