### PR TITLE
fix: enable hot reload for component style files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,230 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a monorepo for the Storybook plugin for StencilJS (`@stencil/storybook-plugin`). The plugin enables developers to build, document, and test StencilJS web components in isolation using Storybook.
+
+**Note**: This project is in early development and maintained by the StencilJS core team.
+
+## Build & Development Commands
+
+This project uses `pnpm` (v10.10.0) and Node.js (v22.2.0).
+
+### Building
+```bash
+pnpm build                  # Build all packages
+pnpm build.plugin           # Build only the plugin package
+pnpm build.example          # Build only the example package
+pnpm build.example-lazy     # Build only the lazy-loaded example package
+```
+
+### Development
+```bash
+pnpm dev                    # Start all dev servers (plugin watch + example storybook)
+pnpm dev.plugin             # Watch mode for plugin development (rebuilds on changes)
+pnpm dev.example            # Run Storybook for the standard example project
+pnpm dev.example-lazy       # Run Storybook for the lazy-loaded example project
+```
+
+When developing the plugin, run `pnpm dev.plugin` in one terminal and `pnpm dev.example` in another to see changes reflected in Storybook at `http://localhost:6006`.
+
+### Testing
+```bash
+pnpm test-all               # Run all tests sequentially
+pnpm test                   # Run e2e tests for standard example (WebdriverIO + Chrome)
+pnpm test.example-lazy      # Run e2e tests for lazy-loaded example
+```
+
+Tests use WebdriverIO with Mocha. E2E tests are located in `tests/` directory and spin up a Storybook instance automatically.
+
+### Code Formatting
+```bash
+pnpm prettier               # Format all code (uses @ionic/prettier-config)
+pnpm prettier.dry-run       # Check formatting without making changes
+```
+
+### Production Storybook Build
+```bash
+pnpm build-storybook        # Build static Storybook for both examples
+```
+
+## Architecture
+
+### Monorepo Structure
+
+```
+packages/
+├── plugin/           # @stencil/storybook-plugin - Core package published to npm
+├── example/          # Example StencilJS project with auto-define-custom-elements
+└── example-lazy/     # Example StencilJS project with lazy-loaded components
+```
+
+### Plugin Package (`packages/plugin/`)
+
+The plugin package is structured to integrate Stencil components into Storybook's architecture:
+
+**Key Entry Points** (defined in `tsdown.config.ts`):
+- `src/index.ts` - Main exports: types, framework API (`setCustomElementsManifest`)
+- `src/preset.ts` - Storybook preset configuration (builder, Vite config, preview annotations)
+- `src/entry-preview.ts` - Core rendering logic for Stencil components
+- `src/entry-preview-argtypes.ts` - ArgTypes extraction from component metadata
+- `src/entry-preview-docs.ts` - Documentation generation
+- `src/node/index.ts` - Node-specific utilities
+
+**Core Rendering** (`src/render.ts`):
+- `render()` - Converts Storybook args/parameters into Stencil JSX (VNodes)
+- `renderToCanvas()` - Renders VNodes to DOM using `@stencil/core`'s `render()` function
+- Handles both lazy-loaded components (string component names) and auto-defined components (constructor references)
+- Supports slots via `parameters.slots` object (keys are slot names, `default` for unnamed slots)
+
+**Vite Integration** (`src/preset.ts`):
+- Uses `unplugin-stencil/vite` to transpile Stencil components within Storybook's Vite builder
+- Configures `@storybook/builder-vite` as the builder
+- Externalizes `@stencil/core` in development mode to avoid bundling issues
+
+**Autodocs System** (`src/docs/`):
+- `custom-elements.ts` - Extracts argTypes, props, events, slots, and CSS custom properties from Stencil's `custom-elements.json` manifest
+- `infer-type.ts` - Infers control types (boolean, number, text, etc.) from component prop types
+- `source-decorator.ts` - Generates source code display in multiple formats (HTML, JSX, TSX)
+- `render-vnode.ts` - Converts Stencil VNodes to HTML/JSX strings for documentation
+
+**Framework API** (`src/framework-api.ts`):
+- `setCustomElementsManifest(customElements)` - Stores the `custom-elements.json` output from Stencil for autodocs
+- Global storage: `__STORYBOOK_CUSTOM_ELEMENTS_MANIFEST__`
+
+**Build System**:
+- Uses `tsdown` for bundling (not tsc)
+- Outputs ESM and CJS formats to `dist/`
+- Externalizes native modules: `fsevents`, `esbuild`, `vite`
+- Target: ES2020, Node.js platform
+
+### Example Packages
+
+Both example packages demonstrate different Stencil output target configurations:
+
+**Standard Example** (`packages/example/`):
+- Uses `customElementsExportBehavior: 'auto-define-custom-elements'`
+- Components auto-register on import
+- Story component value: `component: MyComponent` (constructor)
+- No need to call `defineCustomElements()` in preview
+
+**Lazy Example** (`packages/example-lazy/`):
+- Uses lazy-loaded components (default Stencil behavior with `dist` output target)
+- Requires `defineCustomElements()` call in `.storybook/preview.ts`
+- Story component value: `component: 'my-component'` (string tag name)
+- Components registered at runtime
+
+### Story Writing
+
+Stories use Stencil's JSX syntax via `h` from `@stencil/core`:
+
+```tsx
+import type { Meta, StoryObj } from '@stencil/storybook-plugin';
+import { h } from '@stencil/core';
+import { MyComponent } from './my-component';
+
+const meta = {
+  title: 'MyComponent',
+  component: MyComponent, // or 'my-component' for lazy-loaded
+  args: { first: 'John', last: 'Doe' },
+} satisfies Meta<MyComponent>;
+
+export default meta;
+type Story = StoryObj<MyComponent>;
+
+export const Primary: Story = {
+  args: { first: 'Jane' },
+  render: (props) => <my-component {...props} />
+};
+```
+
+Slots are passed via `parameters.slots`:
+
+```tsx
+{
+  parameters: {
+    slots: {
+      default: 'Hello World',      // Unnamed slot
+      another: <div>Content</div>  // Named slot
+    }
+  }
+}
+```
+
+## Testing Strategy
+
+**E2E Tests** (`tests/`):
+- WebdriverIO spins up Storybook dev server via `pnpm dev.example`
+- Tests navigate to story URLs: `http://localhost:6006/iframe.html?id=...`
+- Chrome browser (headless in CI)
+- Configuration in `wdio.conf.ts` and `wdio.conf-lazy.ts`
+
+**Component Tests**:
+- Individual component tests within packages use Stencil's test runner
+- Test files: `*.spec.ts` (unit), `*.e2e.ts` (e2e per component)
+
+## Stencil Configuration Requirements
+
+For the plugin to work correctly, Stencil projects need:
+
+1. **Docs JSON Output Target** (for autodocs):
+```ts
+{
+  type: 'docs-json',
+  file: 'dist/custom-elements.json'
+}
+```
+
+2. **Component Output Target** (one of):
+   - `dist-custom-elements` with `customElementsExportBehavior: 'auto-define-custom-elements'`
+   - `dist` with lazy loading (requires `defineCustomElements()` call)
+
+3. **Preview Setup** (`.storybook/preview.ts`):
+```ts
+import { setCustomElementsManifest } from '@stencil/storybook-plugin';
+import customElements from '../dist/custom-elements.json';
+
+setCustomElementsManifest(customElements);
+```
+
+## Common Pitfalls
+
+1. **Component not found errors**: Check if story `component` value matches the loading strategy:
+   - Auto-define: use constructor `component: MyComponent`
+   - Lazy-load: use string `component: 'my-component'`
+
+2. **Hot Module Replacement**: Stories completely reload on changes (no HMR yet)
+
+3. **Dev Mode Only**: Stories run in dev mode; no SSR or hydration serialization
+
+4. **Static Dirs**: Example projects set `staticDirs: ['../dist/esm']` to serve component assets
+
+## Release Process
+
+Only maintainers can release via GitHub Actions workflow (`.github/workflows/release.yml`):
+- Manual trigger with version bump type: `patch`, `minor`, `major`
+- Dev releases use format: `version-dev.timestamp.githash`
+- Production releases create Git tags and publish to npm with `latest` tag
+- Only `@stencil/storybook-plugin` is published; examples are private
+
+## Dependencies
+
+**Key Dependencies**:
+- `@stencil/core` - Peer dependency for component compilation and rendering
+- `storybook` - Peer dependency (v9.0.5+)
+- `@storybook/builder-vite` - Vite-based builder
+- `unplugin-stencil` - Vite plugin to compile Stencil components
+- `preact-render-to-string` - Used for VNode serialization
+
+**Dev Tools**:
+- `tsdown` - Build tool (not tsc)
+- `npm-run-all2` - Parallel/sequential script execution
+- `@wdio/cli` - WebdriverIO test runner
+
+## Known Limitations
+
+- No hot module replacement for stories
+- Stories run in dev mode only (no production build testing of components)
+- No automated scaffolding command for adding Storybook to existing Stencil projects

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -64,20 +64,23 @@
     "build": "tsdown"
   },
   "dependencies": {
-    "@storybook/addon-actions": "^9.0.8 || ^10.0.0",
-    "@storybook/builder-vite": "^9.0.8 || ^10.0.0",
     "@storybook/global": "^5.0.0",
-    "@storybook/html": "^9.0.8 || ^10.0.0",
     "preact-render-to-string": "^6.5.13",
     "react-docgen-typescript": "^2.4.0",
     "unplugin-stencil": "^0.4.1"
   },
   "peerDependencies": {
     "@stencil/core": "^4.30.0",
+    "@storybook/addon-actions": "^9.0.8 || ^10.0.0",
+    "@storybook/builder-vite": "^9.0.8 || ^10.0.0",
+    "@storybook/html": "^9.0.8 || ^10.0.0",
     "storybook": "^9.0.5 || ^10.0.0"
   },
   "devDependencies": {
     "@stencil/core": "^4.33.1",
+    "@storybook/addon-actions": "^9.0.8",
+    "@storybook/builder-vite": "^9.0.8",
+    "@storybook/html": "^9.0.8",
     "@types/node": "^22.15.3",
     "tsdown": "^0.12.7",
     "typescript": "~5.8.3",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -64,17 +64,17 @@
     "build": "tsdown"
   },
   "dependencies": {
-    "@storybook/addon-actions": "^9.0.8",
-    "@storybook/builder-vite": "^9.0.8",
+    "@storybook/addon-actions": "^9.0.8 || ^10.0.0",
+    "@storybook/builder-vite": "^9.0.8 || ^10.0.0",
     "@storybook/global": "^5.0.0",
-    "@storybook/html": "^9.0.8",
+    "@storybook/html": "^9.0.8 || ^10.0.0",
     "preact-render-to-string": "^6.5.13",
     "react-docgen-typescript": "^2.4.0",
     "unplugin-stencil": "^0.4.1"
   },
   "peerDependencies": {
     "@stencil/core": "^4.30.0",
-    "storybook": "^9.0.5"
+    "storybook": "^9.0.5 || ^10.0.0"
   },
   "devDependencies": {
     "@stencil/core": "^4.33.1",

--- a/packages/plugin/src/preset.ts
+++ b/packages/plugin/src/preset.ts
@@ -8,6 +8,7 @@ import stencil from 'unplugin-stencil/vite';
 import { fileURLToPath } from 'url';
 import { mergeConfig } from 'vite';
 import { StorybookConfig } from './types';
+import { stencilStylesPlugin } from './vite-plugin-stencil-styles';
 
 const require = createRequire(import.meta.url);
 const getAbsolutePath = <I extends string>(input: I): I => dirname(require.resolve(join(input, 'package.json'))) as any;
@@ -30,6 +31,7 @@ export const viteFinal: StorybookConfig['viteFinal'] = async (defaultConfig, { c
       stencil({
         rootPath: defaultConfig.root,
       }),
+      stencilStylesPlugin(),
     ],
   });
   if (configType === 'DEVELOPMENT') {

--- a/packages/plugin/src/types.ts
+++ b/packages/plugin/src/types.ts
@@ -2,7 +2,6 @@ import { JSX as StencilJSX, VNode } from '@stencil/core';
 import { StorybookConfigVite } from '@storybook/builder-vite';
 import type {
   AnnotatedStoryFn,
-  Args,
   ComponentAnnotations,
   DecoratorFunction,
   StoryContext as GenericStoryContext,
@@ -10,7 +9,6 @@ import type {
   ProjectAnnotations,
   StoryAnnotations,
   StorybookConfig as StorybookConfigBase,
-  StrictArgs,
   WebRenderer,
 } from 'storybook/internal/types';
 
@@ -64,25 +62,25 @@ export type Preview = ProjectAnnotations<StencilRenderer<unknown>>;
  *
  * @see [Default export](https://storybook.js.org/docs/formats/component-story-format/#default-export)
  */
-export type Meta<TArgs = Args> = ComponentAnnotations<StencilRenderer<TArgs>, TArgs>;
+export type Meta<TArgs = Record<string, unknown>> = ComponentAnnotations<StencilRenderer<TArgs>, TArgs>;
 
 /**
  * Story function that represents a CSFv2 component example.
  *
  * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
  */
-export type StoryFn<TArgs = Args> = AnnotatedStoryFn<StencilRenderer<TArgs>, TArgs>;
+export type StoryFn<TArgs = Record<string, unknown>> = AnnotatedStoryFn<StencilRenderer<TArgs>, TArgs>;
 
 /**
  * Story function that represents a CSFv3 component example.
  *
  * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
  */
-export type StoryObj<TArgs = Args> = StoryAnnotations<StencilRenderer<TArgs>, TArgs>;
+export type StoryObj<TArgs = Record<string, unknown>> = StoryAnnotations<StencilRenderer<TArgs>, TArgs>;
 
-export type Decorator<TArgs = StrictArgs> = DecoratorFunction<StencilRenderer<TArgs>, TArgs>;
-export type Loader<TArgs = StrictArgs> = LoaderFunction<StencilRenderer<TArgs>, TArgs>;
-export type StoryContext<TArgs = StrictArgs> = GenericStoryContext<StencilRenderer<TArgs>, TArgs>;
+export type Decorator<TArgs = Record<string, unknown>> = DecoratorFunction<StencilRenderer<TArgs>, TArgs>;
+export type Loader<TArgs = Record<string, unknown>> = LoaderFunction<StencilRenderer<TArgs>, TArgs>;
+export type StoryContext<TArgs = Record<string, unknown>> = GenericStoryContext<StencilRenderer<TArgs>, TArgs>;
 
 export type StorybookConfig = Omit<StorybookConfigBase, 'framework'> & {
   framework: '@stencil/storybook-plugin' | { name: '@stencil/storybook-plugin' };

--- a/packages/plugin/src/types.ts
+++ b/packages/plugin/src/types.ts
@@ -87,6 +87,17 @@ export type StorybookConfig = Omit<StorybookConfigBase, 'framework'> & {
 } & StorybookConfigVite;
 
 /**
+ * Re-export all storybook types so that types inlined into our bundled .d.ts
+ * (e.g. PlayFunctionContext, PlayFunction, Parameters, ArgTypes, Args) are
+ * nameable by consumers. Without these re-exports, consumer code that
+ * transitively references those types via story re-exports trips TS4023
+ * ("...cannot be named") errors. Conflicting names (StoryContext,
+ * StorybookConfig) are shadowed by our explicit exports above.
+ */
+export type * from 'storybook/internal/types';
+export type * from '@storybook/builder-vite';
+
+/**
  * Extend the JSX namespace to include StencilJSX.IntrinsicElements, StencilJSX.Element, and StencilJSX.ElementClass.
  * This is necessary to allow the use of Stencil components in Storybook.
  * Without we get are getting type errors.

--- a/packages/plugin/src/types.ts
+++ b/packages/plugin/src/types.ts
@@ -2,6 +2,7 @@ import { JSX as StencilJSX, VNode } from '@stencil/core';
 import { StorybookConfigVite } from '@storybook/builder-vite';
 import type {
   AnnotatedStoryFn,
+  Args,
   ComponentAnnotations,
   DecoratorFunction,
   StoryContext as GenericStoryContext,
@@ -9,6 +10,7 @@ import type {
   ProjectAnnotations,
   StoryAnnotations,
   StorybookConfig as StorybookConfigBase,
+  StrictArgs,
   WebRenderer,
 } from 'storybook/internal/types';
 
@@ -62,25 +64,25 @@ export type Preview = ProjectAnnotations<StencilRenderer<unknown>>;
  *
  * @see [Default export](https://storybook.js.org/docs/formats/component-story-format/#default-export)
  */
-export type Meta<TArgs = Record<string, unknown>> = ComponentAnnotations<StencilRenderer<TArgs>, TArgs>;
+export type Meta<TArgs = Args> = ComponentAnnotations<StencilRenderer<TArgs>, TArgs>;
 
 /**
  * Story function that represents a CSFv2 component example.
  *
  * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
  */
-export type StoryFn<TArgs = Record<string, unknown>> = AnnotatedStoryFn<StencilRenderer<TArgs>, TArgs>;
+export type StoryFn<TArgs = Args> = AnnotatedStoryFn<StencilRenderer<TArgs>, TArgs>;
 
 /**
  * Story function that represents a CSFv3 component example.
  *
  * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
  */
-export type StoryObj<TArgs = Record<string, unknown>> = StoryAnnotations<StencilRenderer<TArgs>, TArgs>;
+export type StoryObj<TArgs = Args> = StoryAnnotations<StencilRenderer<TArgs>, TArgs>;
 
-export type Decorator<TArgs = Record<string, unknown>> = DecoratorFunction<StencilRenderer<TArgs>, TArgs>;
-export type Loader<TArgs = Record<string, unknown>> = LoaderFunction<StencilRenderer<TArgs>, TArgs>;
-export type StoryContext<TArgs = Record<string, unknown>> = GenericStoryContext<StencilRenderer<TArgs>, TArgs>;
+export type Decorator<TArgs = StrictArgs> = DecoratorFunction<StencilRenderer<TArgs>, TArgs>;
+export type Loader<TArgs = StrictArgs> = LoaderFunction<StencilRenderer<TArgs>, TArgs>;
+export type StoryContext<TArgs = StrictArgs> = GenericStoryContext<StencilRenderer<TArgs>, TArgs>;
 
 export type StorybookConfig = Omit<StorybookConfigBase, 'framework'> & {
   framework: '@stencil/storybook-plugin' | { name: '@stencil/storybook-plugin' };

--- a/packages/plugin/src/vite-plugin-stencil-styles.ts
+++ b/packages/plugin/src/vite-plugin-stencil-styles.ts
@@ -1,0 +1,126 @@
+/**
+ * Vite plugin to watch for style file changes and reload dependent Stencil components.
+ *
+ * Problem: When a Stencil component uses `styleUrl: './component.scss'`, and the style file changes,
+ * Vite doesn't know about this dependency, so the component doesn't reload with the new styles.
+ *
+ * Solution: This plugin:
+ * 1. Tracks which components depend on which style files by reading source code
+ * 2. When a style file changes, "touches" the component file (updates mtime)
+ * 3. Forces unplugin-stencil to recompile the component with the updated styles
+ * 4. Triggers a full page reload to show the changes
+ */
+import { readFileSync, utimesSync } from 'fs';
+import { resolve, dirname, normalize } from 'path';
+import type { Plugin, ViteDevServer } from 'vite';
+
+/**
+ * Extracts style file paths from a Stencil component's @Component decorator.
+ * Supports both `styleUrl` and `styleUrls` properties.
+ */
+function extractStyleUrls(sourceCode: string): string[] {
+  const styleFiles: string[] = [];
+
+  // Match single styleUrl: 'file.css'
+  const styleUrlMatch = sourceCode.match(/styleUrls?:\s*['"`]([^'"`]+)['"`]/);
+  if (styleUrlMatch) {
+    styleFiles.push(styleUrlMatch[1]);
+  }
+
+  // Match array styleUrls: ['file1.css', 'file2.css']
+  const styleUrlsArrayMatch = sourceCode.match(/styleUrls:\s*\[([^\]]+)\]/);
+  if (styleUrlsArrayMatch) {
+    const urls = styleUrlsArrayMatch[1].match(/['"`]([^'"`]+)['"`]/g);
+    if (urls) {
+      styleFiles.push(...urls.map(url => url.replace(/['"`]/g, '')));
+    }
+  }
+
+  return styleFiles;
+}
+
+export function stencilStylesPlugin(): Plugin {
+  // Map of style file paths to the component files that depend on them
+  const styleDependencies = new Map<string, Set<string>>();
+  let server: ViteDevServer | undefined;
+
+  return {
+    name: 'vite-plugin-stencil-styles',
+    enforce: 'pre',
+
+    configureServer(_server) {
+      server = _server;
+    },
+
+    load(id) {
+      const cleanId = id.split('?')[0];
+
+      // Skip non-component files
+      if (
+        (!cleanId.endsWith('.tsx') && !cleanId.endsWith('.ts')) ||
+        cleanId.includes('.stories.') ||
+        cleanId.includes('.storybook') ||
+        cleanId.includes('node_modules')
+      ) {
+        return null;
+      }
+
+      try {
+        const sourceCode = readFileSync(cleanId, 'utf-8');
+
+        // Extract style files from @Component decorator
+        const styleFiles = extractStyleUrls(sourceCode);
+
+        if (styleFiles.length > 0) {
+          const componentDir = dirname(cleanId);
+
+          styleFiles.forEach(styleFile => {
+            const absoluteStylePath = normalize(resolve(componentDir, styleFile));
+
+            if (!styleDependencies.has(absoluteStylePath)) {
+              styleDependencies.set(absoluteStylePath, new Set());
+            }
+            styleDependencies.get(absoluteStylePath)!.add(cleanId);
+          });
+        }
+      } catch {
+        // File doesn't exist on disk (likely a virtual module), skip it
+      }
+
+      return null;
+    },
+
+    handleHotUpdate({ file, server }) {
+      const normalizedFile = normalize(file);
+      const affectedComponents = styleDependencies.get(normalizedFile);
+
+      if (!affectedComponents || affectedComponents.size === 0) {
+        return undefined;
+      }
+
+      // Touch component files to force unplugin-stencil to recompile with updated styles
+      const now = new Date();
+      affectedComponents.forEach(componentId => {
+        try {
+          utimesSync(componentId, now, now);
+        } catch (error) {
+          console.error(`[vite-plugin-stencil-styles] Failed to touch ${componentId}:`, error);
+        }
+
+        // Invalidate the module in Vite's module graph
+        const module = server.moduleGraph.getModuleById(componentId);
+        if (module) {
+          server.moduleGraph.invalidateModule(module);
+        }
+      });
+
+      // Trigger full page reload (HMR won't work since CSS is inlined)
+      server.ws.send({
+        type: 'full-reload',
+        path: '*',
+      });
+
+      return [];
+    },
+  };
+}

--- a/packages/plugin/tsdown.config.ts
+++ b/packages/plugin/tsdown.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
   clean: true,
   dts: {
     sourcemap: true,
+    resolve: true,
   },
   tsconfig: './tsconfig.json',
 });

--- a/packages/plugin/tsdown.config.ts
+++ b/packages/plugin/tsdown.config.ts
@@ -24,7 +24,14 @@ export default defineConfig({
   clean: true,
   dts: {
     sourcemap: true,
-    resolve: true,
+    /**
+     * Inline types from storybook and @storybook/* packages so consumer
+     * workspaces resolve them locally from our bundled .d.ts. @stencil/core
+     * stays external — the consumer always has it installed, and bundling
+     * it would duplicate the `declare global { namespace jest { ... } }`
+     * augmentation, breaking @vitest/expect's JestAssertion inheritance.
+     */
+    resolve: [/^storybook(\/|$)/, /^@storybook\//],
   },
   tsconfig: './tsconfig.json',
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,18 +122,9 @@ importers:
 
   packages/plugin:
     dependencies:
-      '@storybook/addon-actions':
-        specifier: ^9.0.8
-        version: 9.0.8
-      '@storybook/builder-vite':
-        specifier: ^9.0.8
-        version: 9.0.8(storybook@9.0.5(@testing-library/dom@10.4.0)(prettier@3.5.3))(vite@6.3.5(@types/node@22.15.3)(jiti@2.4.2)(tsx@4.19.3))
       '@storybook/global':
         specifier: ^5.0.0
         version: 5.0.0
-      '@storybook/html':
-        specifier: ^9.0.8
-        version: 9.0.8(storybook@9.0.5(@testing-library/dom@10.4.0)(prettier@3.5.3))
       preact-render-to-string:
         specifier: ^6.5.13
         version: 6.5.13(preact@10.26.5)
@@ -141,7 +132,7 @@ importers:
         specifier: ^2.4.0
         version: 2.4.0(typescript@5.8.3)
       storybook:
-        specifier: ^9.0.5
+        specifier: ^9.0.5 || ^10.0.0
         version: 9.0.5(@testing-library/dom@10.4.0)(prettier@3.5.3)
       unplugin-stencil:
         specifier: ^0.4.1
@@ -150,6 +141,15 @@ importers:
       '@stencil/core':
         specifier: ^4.33.1
         version: 4.33.1
+      '@storybook/addon-actions':
+        specifier: ^9.0.8
+        version: 9.0.8
+      '@storybook/builder-vite':
+        specifier: ^9.0.8
+        version: 9.0.8(storybook@9.0.5(@testing-library/dom@10.4.0)(prettier@3.5.3))(vite@6.3.5(@types/node@22.15.3)(jiti@2.4.2)(tsx@4.19.3))
+      '@storybook/html':
+        specifier: ^9.0.8
+        version: 9.0.8(storybook@9.0.5(@testing-library/dom@10.4.0)(prettier@3.5.3))
       '@types/node':
         specifier: ^22.15.3
         version: 22.15.3


### PR DESCRIPTION
Fixes an issue where changes to CSS/SCSS files referenced by Stencil components via styleUrl were not triggering hot reloads in Storybook.

The solution adds a custom Vite plugin that:
- Tracks which components depend on which style files
- When a style file changes, touches the component file to update its mtime
- Forces unplugin-stencil to recompile the component with updated styles
- Triggers a full page reload to display the changes

This works for CSS, SCSS, SASS, and any other style file formats.