### PR TITLE
fix: enable hot reload for component style files

### DIFF
--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -61,7 +61,8 @@
   },
   "scripts": {
     "watch": "tsdown --watch",
-    "build": "tsdown"
+    "build": "tsdown",
+    "test": "vitest run"
   },
   "dependencies": {
     "@storybook/builder-vite": "^10.0.0",
@@ -80,7 +81,8 @@
     "@types/node": "^22.15.3",
     "tsdown": "^0.12.7",
     "typescript": "~5.8.3",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "vitest": "^4.1.6"
   },
   "engines": {
     "node": ">=20"

--- a/packages/plugin/src/preset.ts
+++ b/packages/plugin/src/preset.ts
@@ -8,6 +8,7 @@ import stencil from 'unplugin-stencil/vite';
 import { fileURLToPath } from 'url';
 import { mergeConfig } from 'vite';
 import { StorybookConfig } from './types';
+import { stencilStylesPlugin } from './vite-plugin-stencil-styles';
 
 const require = createRequire(import.meta.url);
 const getAbsolutePath = <I extends string>(input: I): I => dirname(require.resolve(join(input, 'package.json'))) as any;
@@ -30,6 +31,7 @@ export const viteFinal: StorybookConfig['viteFinal'] = async (defaultConfig, { c
       stencil({
         rootPath: defaultConfig.root,
       }),
+      stencilStylesPlugin(),
     ],
   });
   if (configType === 'DEVELOPMENT') {

--- a/packages/plugin/src/vite-plugin-stencil-styles.test.ts
+++ b/packages/plugin/src/vite-plugin-stencil-styles.test.ts
@@ -1,0 +1,193 @@
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, normalize, resolve } from 'path';
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { extractStyleUrls, stencilStylesPlugin } from './vite-plugin-stencil-styles';
+
+describe('extractStyleUrls', () => {
+  it('extracts a single styleUrl', () => {
+    const src = `@Component({ tag: 'x-y', styleUrl: 'x-y.css' })`;
+    expect(extractStyleUrls(src)).toEqual(['x-y.css']);
+  });
+
+  it('supports double, single, and template-literal quotes', () => {
+    expect(extractStyleUrls(`styleUrl: "a.css"`)).toEqual(['a.css']);
+    expect(extractStyleUrls(`styleUrl: 'b.css'`)).toEqual(['b.css']);
+    expect(extractStyleUrls(`styleUrl: \`c.css\``)).toEqual(['c.css']);
+  });
+
+  it('extracts a styleUrls array', () => {
+    const src = `@Component({ tag: 'x-y', styleUrls: ['a.scss', 'b.scss'] })`;
+    expect(extractStyleUrls(src)).toEqual(['a.scss', 'b.scss']);
+  });
+
+  it('extracts a styleUrls array spread across multiple lines', () => {
+    const src = `@Component({
+      tag: 'x-y',
+      styleUrls: [
+        'a.scss',
+        'b.scss',
+      ],
+    })`;
+    expect(extractStyleUrls(src)).toEqual(['a.scss', 'b.scss']);
+  });
+
+  it('extracts mode-based styleUrls object', () => {
+    const src = `@Component({
+      tag: 'x-y',
+      styleUrls: {
+        ios: 'x-y.ios.scss',
+        md: 'x-y.md.scss',
+      },
+    })`;
+    expect(extractStyleUrls(src)).toEqual(['x-y.ios.scss', 'x-y.md.scss']);
+  });
+
+  it('returns empty array when no style references present', () => {
+    expect(extractStyleUrls(`@Component({ tag: 'x-y' })`)).toEqual([]);
+    expect(extractStyleUrls(``)).toEqual([]);
+  });
+
+  it('does not match unrelated property names', () => {
+    expect(extractStyleUrls(`myStyleUrl: 'oops.css'`)).toEqual([]);
+  });
+});
+
+describe('stencilStylesPlugin', () => {
+  let tmpDir: string;
+  let componentPath: string;
+  let stylePath: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'stencil-styles-test-'));
+    mkdirSync(join(tmpDir, 'src', 'components', 'my-thing'), { recursive: true });
+    componentPath = join(tmpDir, 'src', 'components', 'my-thing', 'my-thing.tsx');
+    stylePath = join(tmpDir, 'src', 'components', 'my-thing', 'my-thing.scss');
+    writeFileSync(
+      componentPath,
+      `import { Component } from '@stencil/core';\n@Component({ tag: 'my-thing', styleUrl: 'my-thing.scss' })\nexport class MyThing {}\n`,
+    );
+    writeFileSync(stylePath, `:host { display: block; }\n`);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function getPlugin() {
+    const plugin = stencilStylesPlugin();
+    // call() to bind a minimal `this` context that load/handleHotUpdate don't actually use
+    const load = (id: string) => (plugin.load as any).call({}, id);
+    const handleHotUpdate = (ctx: any) => (plugin.handleHotUpdate as any).call({}, ctx);
+    return { plugin, load, handleHotUpdate };
+  }
+
+  it('skips files that are not .ts/.tsx component sources', () => {
+    const { load } = getPlugin();
+    expect(load(join(tmpDir, 'foo.css'))).toBeNull();
+    expect(load(join(tmpDir, 'foo.stories.tsx'))).toBeNull();
+    expect(load(join(tmpDir, 'node_modules', 'pkg', 'index.ts'))).toBeNull();
+    expect(load(join(tmpDir, '.storybook', 'preview.ts'))).toBeNull();
+  });
+
+  it('silently ignores virtual / non-existent modules', () => {
+    const { load } = getPlugin();
+    expect(() => load(join(tmpDir, 'does-not-exist.ts'))).not.toThrow();
+  });
+
+  it('triggers full-reload + invalidation when a tracked style changes', () => {
+    const { load, handleHotUpdate } = getPlugin();
+    load(componentPath);
+
+    const invalidateModule = vi.fn();
+    const send = vi.fn();
+    const moduleStub = {};
+    const server = {
+      moduleGraph: {
+        getModuleById: vi.fn().mockReturnValue(moduleStub),
+        invalidateModule,
+      },
+      ws: { send },
+    };
+
+    const result = handleHotUpdate({ file: stylePath, server });
+
+    expect(result).toEqual([]);
+    expect(server.moduleGraph.getModuleById).toHaveBeenCalledWith(normalize(componentPath));
+    expect(invalidateModule).toHaveBeenCalledWith(moduleStub);
+    expect(send).toHaveBeenCalledWith({ type: 'full-reload', path: '*' });
+  });
+
+  it('returns undefined for style files not tracked by any component', () => {
+    const { handleHotUpdate } = getPlugin();
+    const send = vi.fn();
+    const server = {
+      moduleGraph: { getModuleById: vi.fn(), invalidateModule: vi.fn() },
+      ws: { send },
+    };
+    const result = handleHotUpdate({ file: join(tmpDir, 'unknown.scss'), server });
+    expect(result).toBeUndefined();
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('strips query strings from module ids', () => {
+    const { load, handleHotUpdate } = getPlugin();
+    load(`${componentPath}?used&lang.tsx`);
+
+    const send = vi.fn();
+    const server = {
+      moduleGraph: { getModuleById: vi.fn().mockReturnValue({}), invalidateModule: vi.fn() },
+      ws: { send },
+    };
+    handleHotUpdate({ file: stylePath, server });
+    expect(send).toHaveBeenCalledWith({ type: 'full-reload', path: '*' });
+  });
+
+  it('tracks multiple components that share the same style file', () => {
+    const otherDir = join(tmpDir, 'src', 'components', 'other');
+    mkdirSync(otherDir, { recursive: true });
+    const otherComponent = join(otherDir, 'other.tsx');
+    // shared.scss is two levels up from `other/other.tsx`
+    const sharedRel = '../my-thing/my-thing.scss';
+    writeFileSync(
+      otherComponent,
+      `import { Component } from '@stencil/core';\n@Component({ tag: 'other', styleUrl: '${sharedRel}' })\nexport class Other {}\n`,
+    );
+
+    const { load, handleHotUpdate } = getPlugin();
+    load(componentPath);
+    load(otherComponent);
+
+    const touched: string[] = [];
+    const server = {
+      moduleGraph: {
+        getModuleById: (id: string) => {
+          touched.push(id);
+          return {};
+        },
+        invalidateModule: vi.fn(),
+      },
+      ws: { send: vi.fn() },
+    };
+
+    handleHotUpdate({ file: stylePath, server });
+    expect(touched.sort()).toEqual([normalize(componentPath), normalize(otherComponent)].sort());
+  });
+
+  it('resolves style paths relative to the component directory', () => {
+    const { load, handleHotUpdate } = getPlugin();
+    writeFileSync(
+      componentPath,
+      `@Component({ tag: 'my-thing', styleUrl: './my-thing.scss' })\nexport class MyThing {}\n`,
+    );
+    load(componentPath);
+
+    const send = vi.fn();
+    const server = {
+      moduleGraph: { getModuleById: vi.fn().mockReturnValue({}), invalidateModule: vi.fn() },
+      ws: { send },
+    };
+    handleHotUpdate({ file: resolve(stylePath), server });
+    expect(send).toHaveBeenCalledWith({ type: 'full-reload', path: '*' });
+  });
+});

--- a/packages/plugin/src/vite-plugin-stencil-styles.ts
+++ b/packages/plugin/src/vite-plugin-stencil-styles.ts
@@ -1,0 +1,126 @@
+/**
+ * Vite plugin to watch for style file changes and reload dependent Stencil components.
+ *
+ * Problem: When a Stencil component uses `styleUrl: './component.scss'`, and the style file changes,
+ * Vite doesn't know about this dependency, so the component doesn't reload with the new styles.
+ *
+ * Solution:
+ * 1. Tracks which components depend on which style files by reading source code in `load()`
+ * 2. When a style file changes, "touches" the component file (updates mtime) so unplugin-stencil
+ *    re-runs its compiler with the updated styles
+ * 3. Invalidates the component module and triggers a full page reload
+ */
+import { readFileSync, utimesSync } from 'fs';
+import { resolve, dirname, normalize } from 'path';
+import type { Plugin } from 'vite';
+
+/**
+ * Extracts style file paths from a Stencil component's @Component decorator.
+ * Supports:
+ *   - `styleUrl: 'file.css'`
+ *   - `styleUrls: ['a.css', 'b.css']`
+ *   - `styleUrls: { ios: 'a.ios.css', md: 'a.md.css' }`
+ */
+export function extractStyleUrls(sourceCode: string): string[] {
+  const styleFiles: string[] = [];
+
+  // Singular: styleUrl: 'file.css'
+  // Note: requires the singular form explicitly so we don't false-match `styleUrls:` when its value
+  // happens to start with a string (would only happen with malformed code anyway).
+  const singularMatch = sourceCode.match(/\bstyleUrl\s*:\s*['"`]([^'"`]+)['"`]/);
+  if (singularMatch) {
+    styleFiles.push(singularMatch[1]);
+  }
+
+  // Array: styleUrls: ['a.css', 'b.css']
+  const arrayMatch = sourceCode.match(/\bstyleUrls\s*:\s*\[([\s\S]*?)\]/);
+  if (arrayMatch) {
+    const urls = arrayMatch[1].match(/['"`]([^'"`]+)['"`]/g);
+    if (urls) {
+      styleFiles.push(...urls.map((url) => url.slice(1, -1)));
+    }
+  }
+
+  // Object (mode-based): styleUrls: { ios: 'a.ios.css', md: 'a.md.css' }
+  const objectMatch = sourceCode.match(/\bstyleUrls\s*:\s*\{([\s\S]*?)\}/);
+  if (objectMatch) {
+    const urls = objectMatch[1].match(/['"`]([^'"`]+)['"`]/g);
+    if (urls) {
+      styleFiles.push(...urls.map((url) => url.slice(1, -1)));
+    }
+  }
+
+  return styleFiles;
+}
+
+function shouldSkip(cleanId: string): boolean {
+  return (
+    (!cleanId.endsWith('.tsx') && !cleanId.endsWith('.ts')) ||
+    cleanId.includes('.stories.') ||
+    cleanId.includes('.storybook') ||
+    cleanId.includes('node_modules')
+  );
+}
+
+export function stencilStylesPlugin(): Plugin {
+  // Map of style file paths to the component files that depend on them
+  const styleDependencies = new Map<string, Set<string>>();
+
+  return {
+    name: 'vite-plugin-stencil-styles',
+    enforce: 'pre',
+
+    load(id) {
+      const cleanId = id.split('?')[0];
+      if (shouldSkip(cleanId)) return null;
+
+      let sourceCode: string;
+      try {
+        sourceCode = readFileSync(cleanId, 'utf-8');
+      } catch {
+        // File doesn't exist on disk (likely a virtual module), skip it
+        return null;
+      }
+
+      const styleFiles = extractStyleUrls(sourceCode);
+      if (styleFiles.length === 0) return null;
+
+      const componentDir = dirname(cleanId);
+      styleFiles.forEach((styleFile) => {
+        const absoluteStylePath = normalize(resolve(componentDir, styleFile));
+        let components = styleDependencies.get(absoluteStylePath);
+        if (!components) {
+          components = new Set();
+          styleDependencies.set(absoluteStylePath, components);
+        }
+        components.add(cleanId);
+      });
+
+      return null;
+    },
+
+    handleHotUpdate({ file, server }) {
+      const normalizedFile = normalize(file);
+      const affectedComponents = styleDependencies.get(normalizedFile);
+      if (!affectedComponents || affectedComponents.size === 0) return undefined;
+
+      // Touch component files so unplugin-stencil re-compiles them with the updated styles
+      const now = new Date();
+      affectedComponents.forEach((componentId) => {
+        try {
+          utimesSync(componentId, now, now);
+        } catch (error) {
+          console.error(`[vite-plugin-stencil-styles] Failed to touch ${componentId}:`, error);
+        }
+        const module = server.moduleGraph.getModuleById(componentId);
+        if (module) {
+          server.moduleGraph.invalidateModule(module);
+        }
+      });
+
+      // Full page reload — HMR can't swap inlined CSS strings inside the compiled component
+      server.ws.send({ type: 'full-reload', path: '*' });
+      return [];
+    },
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,9 @@ importers:
       vite:
         specifier: ^6.3.5
         version: 6.3.5(@types/node@22.15.3)(jiti@2.4.2)(tsx@4.19.3)
+      vitest:
+        specifier: ^4.1.6
+        version: 4.1.6(@types/node@22.15.3)(vite@6.3.5(@types/node@22.15.3)(jiti@2.4.2)(tsx@4.19.3))
 
 packages:
 
@@ -663,6 +666,9 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
 
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
@@ -917,6 +923,9 @@ packages:
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@stencil/core@4.33.1':
     resolution: {integrity: sha512-12k9xhAJBkpg598it+NRmaYIdEe6TSnsL/v6/KRXDcUyTK11VYwZQej2eHnMWtqot+znJ+GNTqb5YbiXi+5Low==}
     engines: {node: '>=16.0.0', npm: '>=7.10.0'}
@@ -1093,20 +1102,49 @@ packages:
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
+  '@vitest/expect@4.1.6':
+    resolution: {integrity: sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==}
+
+  '@vitest/mocker@4.1.6':
+    resolution: {integrity: sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
   '@vitest/pretty-format@2.1.9':
     resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
 
   '@vitest/pretty-format@3.2.4':
     resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
 
+  '@vitest/pretty-format@4.1.6':
+    resolution: {integrity: sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==}
+
+  '@vitest/runner@4.1.6':
+    resolution: {integrity: sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==}
+
   '@vitest/snapshot@2.1.9':
     resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/snapshot@4.1.6':
+    resolution: {integrity: sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==}
 
   '@vitest/spy@3.2.4':
     resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
 
+  '@vitest/spy@4.1.6':
+    resolution: {integrity: sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==}
+
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
+  '@vitest/utils@4.1.6':
+    resolution: {integrity: sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==}
 
   '@wdio/cli@9.12.7':
     resolution: {integrity: sha512-X764hL/nHcbMTepvr7zNF/pSvb4r3twoa5lKllkIIraRDI0cg1/AKHreX24htjHpoA5OLzjEJaydQVJpZ3RzmA==}
@@ -1328,6 +1366,7 @@ packages:
   basic-ftp@5.0.5:
     resolution: {integrity: sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==}
     engines: {node: '>=10.0.0'}
+    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
@@ -1399,6 +1438,10 @@ packages:
   chai@5.2.0:
     resolution: {integrity: sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==}
     engines: {node: '>=12'}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@3.0.0:
     resolution: {integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==}
@@ -1738,6 +1781,9 @@ packages:
   error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
 
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
   esbuild@0.25.2:
     resolution: {integrity: sha512-16854zccKPnC+toMywC+uKNeYSv+/eXkevRAfwRD/G9Cleq66m8XFIrigkbvauLLlCfDL45Q2cWegSg53gGBnQ==}
     engines: {node: '>=18'}
@@ -1769,6 +1815,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -1792,6 +1841,10 @@ packages:
   exit@0.1.2:
     resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
     engines: {node: '>= 0.8.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   expect-webdriverio@5.1.0:
     resolution: {integrity: sha512-4u3q+Dqx/lXNgvCx1gKia4CfS28z1UxGGfVUkoMNbrsBlTBB2fYqXG+4+YtYoerxvp/XPwIb/+89IGEdyPbDXQ==}
@@ -1835,6 +1888,15 @@ packages:
 
   fdir@6.4.4:
     resolution: {integrity: sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
     peerDependencies:
       picomatch: ^3 || ^4
     peerDependenciesMeta:
@@ -1937,16 +1999,17 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
@@ -2423,6 +2486,9 @@ packages:
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
@@ -2540,6 +2606,9 @@ packages:
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -2676,6 +2745,10 @@ packages:
 
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
   pidtree@0.6.0:
@@ -2957,6 +3030,9 @@ packages:
     resolution: {integrity: sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -3022,6 +3098,12 @@ packages:
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   storybook@10.2.17:
     resolution: {integrity: sha512-yueTpl5YJqLzQqs3CanxNdAAfFU23iP0j+JVJURE4ghfEtRmWfWoZWLGkVcyjmgum7UmjwAlqRuOjQDNvH89kw==}
@@ -3116,11 +3198,22 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@1.0.1:
     resolution: {integrity: sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==}
 
+  tinyexec@1.1.2:
+    resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.14:
     resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
   tinyrainbow@1.2.0:
@@ -3129,6 +3222,10 @@ packages:
 
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
   tinyspy@4.0.4:
@@ -3328,6 +3425,47 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.6:
+    resolution: {integrity: sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.6
+      '@vitest/browser-preview': 4.1.6
+      '@vitest/browser-webdriverio': 4.1.6
+      '@vitest/coverage-istanbul': 4.1.6
+      '@vitest/coverage-v8': 4.1.6
+      '@vitest/ui': 4.1.6
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   wait-port@1.1.0:
     resolution: {integrity: sha512-3e04qkoN3LxTMLakdqeWth8nih8usyg+sf1Bgdf9wwUkp05iuK1eSY/QpLvscT/+F/gA89+LpUmmgBtesbqI2Q==}
     engines: {node: '>=10'}
@@ -3362,6 +3500,7 @@ packages:
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
@@ -3375,6 +3514,11 @@ packages:
   which@5.0.0:
     resolution: {integrity: sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   workerpool@6.5.1:
@@ -4074,6 +4218,8 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.0': {}
 
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
   '@jridgewell/trace-mapping@0.3.25':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
@@ -4257,6 +4403,8 @@ snapshots:
   '@sinonjs/fake-timers@10.3.0':
     dependencies:
       '@sinonjs/commons': 3.0.1
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@stencil/core@4.33.1':
     optionalDependencies:
@@ -4472,6 +4620,23 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
+  '@vitest/expect@4.1.6':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.6
+      '@vitest/utils': 4.1.6
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.6(vite@6.3.5(@types/node@22.15.3)(jiti@2.4.2)(tsx@4.19.3))':
+    dependencies:
+      '@vitest/spy': 4.1.6
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.3.5(@types/node@22.15.3)(jiti@2.4.2)(tsx@4.19.3)
+
   '@vitest/pretty-format@2.1.9':
     dependencies:
       tinyrainbow: 1.2.0
@@ -4480,21 +4645,45 @@ snapshots:
     dependencies:
       tinyrainbow: 2.0.0
 
+  '@vitest/pretty-format@4.1.6':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.6':
+    dependencies:
+      '@vitest/utils': 4.1.6
+      pathe: 2.0.3
+
   '@vitest/snapshot@2.1.9':
     dependencies:
       '@vitest/pretty-format': 2.1.9
       magic-string: 0.30.17
       pathe: 1.1.2
 
+  '@vitest/snapshot@4.1.6':
+    dependencies:
+      '@vitest/pretty-format': 4.1.6
+      '@vitest/utils': 4.1.6
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
   '@vitest/spy@3.2.4':
     dependencies:
       tinyspy: 4.0.4
+
+  '@vitest/spy@4.1.6': {}
 
   '@vitest/utils@3.2.4':
     dependencies:
       '@vitest/pretty-format': 3.2.4
       loupe: 3.2.1
       tinyrainbow: 2.0.0
+
+  '@vitest/utils@4.1.6':
+    dependencies:
+      '@vitest/pretty-format': 4.1.6
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@wdio/cli@9.12.7(puppeteer-core@24.6.1)':
     dependencies:
@@ -4899,6 +5088,8 @@ snapshots:
       loupe: 3.2.1
       pathval: 2.0.0
 
+  chai@6.2.2: {}
+
   chalk@3.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -5214,6 +5405,8 @@ snapshots:
     dependencies:
       is-arrayish: 0.2.1
 
+  es-module-lexer@2.1.0: {}
+
   esbuild@0.25.2:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.25.2
@@ -5260,6 +5453,10 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.7
+
   esutils@2.0.3: {}
 
   event-target-shim@5.0.1: {}
@@ -5294,6 +5491,8 @@ snapshots:
       yoctocolors: 2.1.1
 
   exit@0.1.2: {}
+
+  expect-type@1.3.0: {}
 
   expect-webdriverio@5.1.0(@wdio/globals@9.12.7(@wdio/logger@9.4.4)(puppeteer-core@24.6.1))(@wdio/logger@9.4.4)(webdriverio@9.12.7(puppeteer-core@24.6.1)):
     dependencies:
@@ -5350,6 +5549,14 @@ snapshots:
   fdir@6.4.4(picomatch@4.0.2):
     optionalDependencies:
       picomatch: 4.0.2
+
+  fdir@6.4.4(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
 
   fetch-blob@3.2.0:
     dependencies:
@@ -6093,6 +6300,10 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   make-dir@4.0.0:
     dependencies:
       semver: 7.7.2
@@ -6217,6 +6428,8 @@ snapshots:
       boolbase: 1.0.0
 
   object-inspect@1.13.4: {}
+
+  obug@2.1.1: {}
 
   once@1.4.0:
     dependencies:
@@ -6349,6 +6562,8 @@ snapshots:
   picomatch@4.0.2: {}
 
   picomatch@4.0.3: {}
+
+  picomatch@4.0.4: {}
 
   pidtree@0.6.0: {}
 
@@ -6675,6 +6890,8 @@ snapshots:
 
   shell-quote@1.8.2: {}
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -6732,6 +6949,10 @@ snapshots:
   stack-utils@2.0.6:
     dependencies:
       escape-string-regexp: 2.0.0
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
 
   storybook@10.2.17(@testing-library/dom@10.4.0)(prettier@3.5.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
@@ -6850,16 +7071,27 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
+  tinybench@2.9.0: {}
+
   tinyexec@1.0.1: {}
+
+  tinyexec@1.1.2: {}
 
   tinyglobby@0.2.14:
     dependencies:
-      fdir: 6.4.4(picomatch@4.0.2)
-      picomatch: 4.0.2
+      fdir: 6.4.4(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinyrainbow@1.2.0: {}
 
   tinyrainbow@2.0.0: {}
+
+  tinyrainbow@3.1.0: {}
 
   tinyspy@4.0.4: {}
 
@@ -6997,6 +7229,33 @@ snapshots:
       jiti: 2.4.2
       tsx: 4.19.3
 
+  vitest@4.1.6(@types/node@22.15.3)(vite@6.3.5(@types/node@22.15.3)(jiti@2.4.2)(tsx@4.19.3)):
+    dependencies:
+      '@vitest/expect': 4.1.6
+      '@vitest/mocker': 4.1.6(vite@6.3.5(@types/node@22.15.3)(jiti@2.4.2)(tsx@4.19.3))
+      '@vitest/pretty-format': 4.1.6
+      '@vitest/runner': 4.1.6
+      '@vitest/snapshot': 4.1.6
+      '@vitest/spy': 4.1.6
+      '@vitest/utils': 4.1.6
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 6.3.5(@types/node@22.15.3)(jiti@2.4.2)(tsx@4.19.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.15.3
+    transitivePeerDependencies:
+      - msw
+
   wait-port@1.1.0:
     dependencies:
       chalk: 4.1.2
@@ -7084,6 +7343,11 @@ snapshots:
   which@5.0.0:
     dependencies:
       isexe: 3.1.1
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   workerpool@6.5.1: {}
 


### PR DESCRIPTION
Supersedes #39 by @gavmck (credit goes to him for the original Vite plugin design and implementation). I verified the original PR end-to-end against current `main` (it still applies cleanly and works), then extended it as follows.

## Summary
- **Same approach as #39**: a Vite plugin that scans Stencil component sources during `load()` to record which `styleUrl(s)` each component depends on, then on `handleHotUpdate` touches the component file's mtime so `unplugin-stencil` recompiles it, and fires a full page reload.
- **Adds support for mode-based `styleUrls` object form**: `styleUrls: { ios: 'a.ios.scss', md: 'a.md.scss' }` is a documented Stencil pattern that #39 missed.
- **Removes dead code**: the original `configureServer` captured a `server` reference that was never used (the active `server` always comes from the `handleHotUpdate` context).
- **Adds tests**: 14 vitest cases covering `extractStyleUrls` (single string, array — including multiline, mode-based object, quote variants, no match, false-positive guard) and the plugin flow (skip rules, virtual modules, query-string ids, multi-component shared style, relative paths, full-reload + module invalidation, untracked styles).

## Verification
Ran the example storybook (`packages/example`) on this branch, requested `my-component.tsx` from the dev server so the dep map populates, edited `my-component.css`, and saw:
- `Vite page reload src/components/my-component/my-component.tsx` in the dev-server log
- The next module fetch returned the recompiled component with the new `myComponentCss = "..."` string

## Test plan
- [ ] `pnpm --filter @stencil/storybook-plugin test` passes (14/14 locally)
- [ ] `pnpm --filter @stencil/storybook-plugin build` passes
- [ ] `pnpm --filter example storybook` and edit a component `.css`/`.scss` — page reloads with new styles
- [ ] Manual check with `styleUrls: { ios, md }` if a project uses mode-based styles

Closes #39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)