### PR TITLE
fix(plugin): reload preview iframe on Stencil component changes

### DIFF
--- a/packages/example-lazy/.storybook/main.ts
+++ b/packages/example-lazy/.storybook/main.ts
@@ -2,12 +2,7 @@ import type { StorybookConfig } from '@stencil/storybook-plugin';
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.stories.@(js|jsx|ts|tsx)'],
-  staticDirs: [
-    {
-      from: '../dist/esm',
-      to: 'assets',
-    },
-  ],
+  staticDirs: ['../dist/esm'],
   addons: ['@storybook/addon-links', '@storybook/addon-docs'],
   core: {
     disableTelemetry: true,

--- a/packages/example-lazy/.storybook/preview.tsx
+++ b/packages/example-lazy/.storybook/preview.tsx
@@ -2,10 +2,8 @@ import { setCustomElementsManifest, type Preview } from '@stencil/storybook-plug
 import customElements from '../dist/custom-elements.json';
 import { defineCustomElements } from '../loader';
 
+defineCustomElements();
 setCustomElementsManifest(customElements);
-defineCustomElements(window, {
-  resourcesUrl: '/assets/',
-});
 
 export const parameters: Preview['parameters'] = {
   actions: { argTypesRegex: '^on[A-Z].*' },

--- a/packages/example/.storybook/main.ts
+++ b/packages/example/.storybook/main.ts
@@ -1,4 +1,6 @@
-const config = {
+import type { StorybookConfig } from '@stencil/storybook-plugin';
+
+const config: StorybookConfig = {
   stories: ['../src/**/*.stories.@(js|jsx|ts|tsx)'],
   staticDirs: ['../dist/esm'],
   addons: ['@storybook/addon-links', '@storybook/addon-docs'],

--- a/packages/plugin/src/entry-preview.ts
+++ b/packages/plugin/src/entry-preview.ts
@@ -6,3 +6,10 @@ export const parameters: Parameters = { renderer: 'stencil' };
 export { render, renderToCanvas } from './render';
 
 export const argTypesEnhancers: ArgTypesEnhancer[] = [enhanceArgTypes];
+
+// Reload the iframe when a Stencil component .tsx is rebuilt — see preset.ts.
+if (import.meta.hot) {
+  import.meta.hot.on('stencil:reload', () => {
+    location.reload();
+  });
+}

--- a/packages/plugin/src/preset.ts
+++ b/packages/plugin/src/preset.ts
@@ -39,11 +39,133 @@ export const viteFinal: StorybookConfig['viteFinal'] = async (defaultConfig, { c
           external: ['@stencil/core'],
         },
       },
+      // Don't let Vite watch this plugin's own `dist/`. `tsdown --watch`
+      // rewrites those files during plugin development; if Vite picks the
+      // change up it re-optimizes deps, bumping the React chunk hash and
+      // leaving previously-imported chunks pointing at a torn-down React
+      // (`useEffect` becomes null in <DocsContainer>).
+      server: {
+        watch: {
+          ignored: [join(__dirname, '**')],
+        },
+      },
+      plugins: [stencilPreviewReloadPlugin()],
     });
   }
 
   return config;
 };
+
+/**
+ * Forces a full preview reload when a Stencil component changes.
+ *
+ * `customElements.define()` is permanent, so HMR can't swap the new class in —
+ * the iframe must reload. We use a custom HMR event (instead of Vite's
+ * `full-reload`) because Storybook's story-index watcher races us with its own
+ * `vite-app.js` HMR update and cancels plain reloads.
+ *
+ * - Eager: the .tsx is in Vite's graph; our `transform` hook fires after
+ *   unplugin-stencil and emits the reload.
+ * - Lazy: the .tsx isn't imported, so we run unplugin-stencil ourselves, wait
+ *   for `dist/esm/*.entry.js` to be rewritten (Stencil's build is async), then
+ *   reload.
+ */
+function stencilPreviewReloadPlugin() {
+  let devServer: any;
+  let lazyBuildPending = false;
+
+  const sendReload = (server: any) => {
+    server.ws.send({ type: 'custom', event: 'stencil:reload' });
+  };
+
+  return {
+    name: 'stencil-preview-reload',
+
+    configureServer(server: any) {
+      devServer = server;
+
+      server.watcher.on('change', async (file: string) => {
+        if (!file.endsWith('.tsx') || file.endsWith('.stories.tsx')) return;
+
+        const mod = server.moduleGraph.getModuleById(file);
+        // Eager components are handled by the `transform` hook below.
+        if (mod && mod.importers.size > 0) return;
+
+        // Lazy: trigger Stencil's build manually, then poll mtimes since
+        // unplugin-stencil's transform resolves before the build flushes to disk.
+        const stencilPlugin = server.config.plugins.find((p: any) => p.name === 'unplugin-stencil');
+        if (!stencilPlugin?.transform) return;
+
+        const { readFileSync, statSync, existsSync, readdirSync } = await import('fs');
+        const distDir = join(server.config.root, 'dist', 'esm');
+        const snapshotMtimes = (): Record<string, number> => {
+          if (!existsSync(distDir)) return {};
+          const out: Record<string, number> = {};
+          for (const f of readdirSync(distDir)) {
+            if (!f.endsWith('.entry.js')) continue;
+            try {
+              out[f] = statSync(join(distDir, f)).mtimeMs;
+            } catch {
+              // file may be removed mid-scan
+            }
+          }
+          return out;
+        };
+        const before = snapshotMtimes();
+
+        lazyBuildPending = true;
+        try {
+          const code = readFileSync(file, 'utf-8');
+          await stencilPlugin.transform.call({ resolve: (): null => null }, code, file);
+        } catch {
+          lazyBuildPending = false;
+          return;
+        }
+
+        const deadline = Date.now() + 5000;
+        const tick = (): void => {
+          if (!lazyBuildPending) return;
+          const after = snapshotMtimes();
+          const changed = Object.keys(after).some((f) => !(f in before) || after[f] > before[f]);
+          if (changed) {
+            lazyBuildPending = false;
+            // dist/esm lives outside Vite's watched root, so its module cache
+            // never invalidates on its own. Drop it before reloading.
+            for (const cached of server.moduleGraph.idToModuleMap.values()) {
+              if (cached.id && cached.id.includes('/dist/esm/') && cached.id.endsWith('.js')) {
+                server.moduleGraph.invalidateModule(cached);
+              }
+            }
+            sendReload(server);
+            return;
+          }
+          if (Date.now() > deadline) {
+            lazyBuildPending = false;
+            return;
+          }
+          setTimeout(tick, 50);
+        };
+        tick();
+      });
+    },
+
+    // Always reload (never HMR) for component .tsx files. Eager modules still
+    // need to flow through Vite so unplugin-stencil rebuilds dist.
+    handleHotUpdate({ file, modules }: { file: string; server: any; modules: any[] }): any[] | undefined {
+      if (!file.endsWith('.tsx') || file.endsWith('.stories.tsx')) return;
+      const mod = modules[0];
+      if (mod && mod.importers?.size > 0) return;
+      return [];
+    },
+
+    async transform(_code: string, id: string) {
+      if (!devServer) return;
+      if (!id.endsWith('.tsx') || id.endsWith('.stories.tsx')) return;
+      if (lazyBuildPending) return;
+      sendReload(devServer);
+    },
+  };
+}
 
 export const previewAnnotations: StorybookConfig['previewAnnotations'] = async (input = [], options) => {
   const docsEnabled = Object.keys(await options.presets.apply('docs', {}, options)).length > 0;

--- a/packages/plugin/src/preset.ts
+++ b/packages/plugin/src/preset.ts
@@ -2,10 +2,12 @@
  * we can't prefix the Node.js imports with `node:` because it will break
  * within Storybook due to its Vite setup.
  */
+import { existsSync, readdirSync, readFileSync, statSync } from 'fs';
 import { createRequire } from 'module';
-import { dirname, join } from 'path';
+import { dirname, join, sep } from 'path';
 import stencil from 'unplugin-stencil/vite';
 import { fileURLToPath } from 'url';
+import type { HmrContext, Plugin, ViteDevServer } from 'vite';
 import { mergeConfig } from 'vite';
 import { StorybookConfig } from './types';
 
@@ -70,19 +72,37 @@ export const viteFinal: StorybookConfig['viteFinal'] = async (defaultConfig, { c
  *   for `dist/esm/*.entry.js` to be rewritten (Stencil's build is async), then
  *   reload.
  */
-function stencilPreviewReloadPlugin() {
-  let devServer: any;
+function stencilPreviewReloadPlugin(): Plugin {
+  let devServer: ViteDevServer | undefined;
   let lazyBuildPending = false;
 
-  const sendReload = (server: any) => {
+  const sendReload = (server: ViteDevServer) => {
     server.ws.send({ type: 'custom', event: 'stencil:reload' });
   };
+
+  // Match dist/esm module ids on both POSIX and Windows.
+  const distEsmFragment = `${sep}dist${sep}esm${sep}`;
 
   return {
     name: 'stencil-preview-reload',
 
-    configureServer(server: any) {
+    configureServer(server) {
       devServer = server;
+      const distDir = join(server.config.root, 'dist', 'esm');
+
+      const snapshotMtimes = (): Record<string, number> => {
+        if (!existsSync(distDir)) return {};
+        const out: Record<string, number> = {};
+        for (const f of readdirSync(distDir)) {
+          if (!f.endsWith('.entry.js')) continue;
+          try {
+            out[f] = statSync(join(distDir, f)).mtimeMs;
+          } catch {
+            // file may be removed mid-scan
+          }
+        }
+        return out;
+      };
 
       server.watcher.on('change', async (file: string) => {
         if (!file.endsWith('.tsx') || file.endsWith('.stories.tsx')) return;
@@ -93,30 +113,15 @@ function stencilPreviewReloadPlugin() {
 
         // Lazy: trigger Stencil's build manually, then poll mtimes since
         // unplugin-stencil's transform resolves before the build flushes to disk.
-        const stencilPlugin = server.config.plugins.find((p: any) => p.name === 'unplugin-stencil');
-        if (!stencilPlugin?.transform) return;
+        const stencilPlugin = server.config.plugins.find((p) => p.name === 'unplugin-stencil');
+        if (!stencilPlugin || typeof stencilPlugin.transform !== 'function') return;
 
-        const { readFileSync, statSync, existsSync, readdirSync } = await import('fs');
-        const distDir = join(server.config.root, 'dist', 'esm');
-        const snapshotMtimes = (): Record<string, number> => {
-          if (!existsSync(distDir)) return {};
-          const out: Record<string, number> = {};
-          for (const f of readdirSync(distDir)) {
-            if (!f.endsWith('.entry.js')) continue;
-            try {
-              out[f] = statSync(join(distDir, f)).mtimeMs;
-            } catch {
-              // file may be removed mid-scan
-            }
-          }
-          return out;
-        };
         const before = snapshotMtimes();
 
         lazyBuildPending = true;
         try {
           const code = readFileSync(file, 'utf-8');
-          await stencilPlugin.transform.call({ resolve: (): null => null }, code, file);
+          await (stencilPlugin.transform as any).call({ resolve: (): null => null }, code, file);
         } catch {
           lazyBuildPending = false;
           return;
@@ -132,7 +137,7 @@ function stencilPreviewReloadPlugin() {
             // dist/esm lives outside Vite's watched root, so its module cache
             // never invalidates on its own. Drop it before reloading.
             for (const cached of server.moduleGraph.idToModuleMap.values()) {
-              if (cached.id && cached.id.includes('/dist/esm/') && cached.id.endsWith('.js')) {
+              if (cached.id && cached.id.includes(distEsmFragment) && cached.id.endsWith('.js')) {
                 server.moduleGraph.invalidateModule(cached);
               }
             }
@@ -151,14 +156,15 @@ function stencilPreviewReloadPlugin() {
 
     // Always reload (never HMR) for component .tsx files. Eager modules still
     // need to flow through Vite so unplugin-stencil rebuilds dist.
-    handleHotUpdate({ file, modules }: { file: string; server: any; modules: any[] }): any[] | undefined {
+    handleHotUpdate(ctx: HmrContext) {
+      const { file, modules } = ctx;
       if (!file.endsWith('.tsx') || file.endsWith('.stories.tsx')) return;
       const mod = modules[0];
       if (mod && mod.importers?.size > 0) return;
       return [];
     },
 
-    async transform(_code: string, id: string) {
+    async transform(_code, id) {
       if (!devServer) return;
       if (!id.endsWith('.tsx') || id.endsWith('.stories.tsx')) return;
       if (lazyBuildPending) return;

--- a/packages/plugin/src/render.ts
+++ b/packages/plugin/src/render.ts
@@ -15,11 +15,16 @@ export const render: ArgsStoryFn<StencilRenderer<unknown>> = (args, context) => 
       `Stencil component not found. If you are not lazy loading your components with \`defineCustomElements()\` in preview.ts, pass a constructor value for component in your story \`component: MyComponent\``,
     );
   } else if (typeof component !== 'string' && !customElements.getName(component)) {
-    throw new Error(
-      `Stencil component not found. If you are lazy loading your components with \`defineCustomElements()\` in preview.ts, pass a string value for component in your story \`component: 'my-component'\``,
-    );
+    // After HMR the module re-evaluates and produces a new class reference, so
+    // getName returns null even though the tag is still registered under component.is.
+    if (!(component as any).is || !customElements.get((component as any).is)) {
+      throw new Error(
+        `Stencil component not found. If you are lazy loading your components with \`defineCustomElements()\` in preview.ts, pass a string value for component in your story \`component: 'my-component'\``,
+      );
+    }
   }
-  const cmpName = typeof component === 'string' ? component : customElements.getName(component);
+  const cmpName =
+    typeof component === 'string' ? component : (customElements.getName(component) ?? (component as any).is);
 
   const children: any[] = Object.entries<VNode>(parameters.slots || []).map(([key, value]) => {
     // if the parameter key is 'default' don't give it a slot name so it renders just as a child

--- a/packages/plugin/src/typing.d.ts
+++ b/packages/plugin/src/typing.d.ts
@@ -1,2 +1,8 @@
 declare var __STORYBOOK_CUSTOM_ELEMENTS_MANIFEST__: any;
 declare var __STORYBOOK_CUSTOM_ELEMENTS__: any;
+
+interface ImportMeta {
+  hot?: {
+    on(event: string, cb: (...args: any[]) => void): void;
+  };
+}

--- a/packages/plugin/tsdown.config.ts
+++ b/packages/plugin/tsdown.config.ts
@@ -1,5 +1,10 @@
 import { defineConfig } from 'tsdown';
 
+// In watch mode tsdown cleans dist before the first build, which races with
+// Storybook startup. Skip cleaning when watching so the previous build stays
+// in place until the new one is ready.
+const watching = process.argv.includes('--watch') || process.argv.includes('-w');
+
 export default defineConfig({
   entry: [
     './src/index.ts',
@@ -21,7 +26,7 @@ export default defineConfig({
   target: 'es2020',
   platform: 'node',
   sourcemap: true,
-  clean: true,
+  clean: !watching,
   dts: {
     sourcemap: true,
   },

--- a/tests/hmr.e2e.ts
+++ b/tests/hmr.e2e.ts
@@ -1,0 +1,117 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import url from 'node:url';
+
+import { $, browser, expect } from '@wdio/globals';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+
+const PACKAGE = process.env.STENCIL_HMR_PACKAGE ?? 'example';
+const COMPONENT_PATH = path.resolve(
+  __dirname,
+  '..',
+  'packages',
+  PACKAGE,
+  'src',
+  'components',
+  'my-component',
+  'my-component.tsx',
+);
+
+const ORIGINAL_RENDER = `    return <div>Hello, World! I'm {this.getText()}</div>;`;
+
+function makeUpdatedRender(token: string) {
+  return `    return <div>Hello, ${token}! I'm {this.getText()}</div>;`;
+}
+
+async function readMyComponentText() {
+  await browser.switchFrame(null);
+  await browser.switchFrame(() => Boolean(document.querySelector('my-component')));
+  const el = await $('my-component');
+  await el.waitForExist({ timeout: 15000 });
+  return browser.execute(() => {
+    const host = document.querySelector('my-component');
+    const root = host?.shadowRoot ?? host;
+    return root?.textContent?.trim() ?? '';
+  });
+}
+
+describe(`StencilJS Storybook HMR (${PACKAGE})`, () => {
+  let originalSource: string | undefined;
+
+  before(async () => {
+    originalSource = fs.readFileSync(COMPONENT_PATH, 'utf-8');
+    if (!originalSource.includes(ORIGINAL_RENDER)) {
+      throw new Error(
+        `HMR test expected ${COMPONENT_PATH} to contain the canonical render line. Update the test or restore the file.`,
+      );
+    }
+
+    await browser.url(`/?path=/story/mycomponent--primary`);
+    // give Storybook a moment to mount the iframe
+    await browser.pause(3000);
+  });
+
+  afterEach(async () => {
+    await browser.switchFrame(null);
+  });
+
+  after(() => {
+    if (originalSource !== undefined) {
+      fs.writeFileSync(COMPONENT_PATH, originalSource, 'utf-8');
+    }
+  });
+
+  it('renders the original component before any edits', async () => {
+    const text = await readMyComponentText();
+    await expect(text).toContain('Hello, World!');
+  });
+
+  it('reloads the preview iframe when the component .tsx changes', async () => {
+    const token = `HMR_${Date.now()}`;
+    const updated = (originalSource as string).replace(ORIGINAL_RENDER, makeUpdatedRender(token));
+    if (updated === originalSource) {
+      throw new Error('Failed to produce an updated source for HMR test.');
+    }
+
+    fs.writeFileSync(COMPONENT_PATH, updated, 'utf-8');
+
+    try {
+      await browser.waitUntil(
+        async () => {
+          try {
+            const text = await readMyComponentText();
+            return text.includes(`Hello, ${token}!`);
+          } catch {
+            return false;
+          }
+        },
+        {
+          // Lazy builds re-run the Stencil compiler, so allow extra time.
+          timeout: 60000,
+          interval: 1000,
+          timeoutMsg: `Component never picked up edited render output for token ${token}`,
+        },
+      );
+    } finally {
+      fs.writeFileSync(COMPONENT_PATH, originalSource as string, 'utf-8');
+    }
+
+    // After restoring the file the preview should hot-reload back to "World".
+    await browser.waitUntil(
+      async () => {
+        try {
+          const text = await readMyComponentText();
+          return text.includes('Hello, World!');
+        } catch {
+          return false;
+        }
+      },
+      {
+        timeout: 60000,
+        interval: 1000,
+        timeoutMsg: 'Component did not return to the original render after restoring the file',
+      },
+    );
+  });
+});

--- a/tests/hmr.e2e.ts
+++ b/tests/hmr.e2e.ts
@@ -19,6 +19,9 @@ const COMPONENT_PATH = path.resolve(
 );
 
 const ORIGINAL_RENDER = `    return <div>Hello, World! I'm {this.getText()}</div>;`;
+// Matches any prior HMR mutation of the render line so we can self-heal a file
+// left dirty by a previous run that died before its cleanup hook fired.
+const RENDER_LINE_PATTERN = /^ {4}return <div>Hello, [^!]+! I'm \{this\.getText\(\)\}<\/div>;$/m;
 
 function makeUpdatedRender(token: string) {
   return `    return <div>Hello, ${token}! I'm {this.getText()}</div>;`;
@@ -29,6 +32,16 @@ async function readMyComponentText() {
   await browser.switchFrame(() => Boolean(document.querySelector('my-component')));
   const el = await $('my-component');
   await el.waitForExist({ timeout: 15000 });
+  // The lazy loader places <my-component> in the DOM immediately and hydrates
+  // it asynchronously from `dist/esm/*.entry.js`. Wait for the canonical
+  // `hydrated` class before reading text so we don't see an empty shadow root.
+  await browser.waitUntil(
+    async () => {
+      const cls = await $('my-component').getAttribute('class');
+      return typeof cls === 'string' && cls.split(/\s+/).includes('hydrated');
+    },
+    { timeout: 15000, interval: 200, timeoutMsg: 'my-component never reached the `hydrated` state' },
+  );
   return browser.execute(() => {
     const host = document.querySelector('my-component');
     const root = host?.shadowRoot ?? host;
@@ -40,16 +53,36 @@ describe(`StencilJS Storybook HMR (${PACKAGE})`, () => {
   let originalSource: string | undefined;
 
   before(async () => {
-    originalSource = fs.readFileSync(COMPONENT_PATH, 'utf-8');
-    if (!originalSource.includes(ORIGINAL_RENDER)) {
-      throw new Error(
-        `HMR test expected ${COMPONENT_PATH} to contain the canonical render line. Update the test or restore the file.`,
-      );
+    const onDisk = fs.readFileSync(COMPONENT_PATH, 'utf-8');
+
+    if (onDisk.includes(ORIGINAL_RENDER)) {
+      originalSource = onDisk;
+    } else {
+      // A previous run may have died before its `after` hook restored the
+      // file. Heal the canonical render line so the suite can proceed.
+      const healed = onDisk.replace(RENDER_LINE_PATTERN, ORIGINAL_RENDER);
+      if (!healed.includes(ORIGINAL_RENDER)) {
+        throw new Error(`HMR test could not self-heal ${COMPONENT_PATH}; restore the canonical render line manually.`);
+      }
+      // eslint-disable-next-line no-console
+      console.warn(`[hmr.e2e] Detected leftover mutation in ${COMPONENT_PATH}; self-healing to canonical render line.`);
+      fs.writeFileSync(COMPONENT_PATH, healed, 'utf-8');
+      originalSource = healed;
     }
 
     await browser.url(`/?path=/story/mycomponent--primary`);
-    // give Storybook a moment to mount the iframe
-    await browser.pause(3000);
+    const iframe = $('#storybook-preview-iframe');
+    await iframe.waitForExist({ timeout: 30000 });
+    // Storybook flips this to "true" only once the preview iframe has booted
+    // and a story is rendered. Without this we can switch into a still-empty
+    // iframe and time out waiting for <my-component>.
+    await browser.waitUntil(
+      async () => (await iframe.getAttribute('data-is-loaded')) === 'true',
+      { timeout: 60000, interval: 250, timeoutMsg: 'Storybook preview iframe never reached data-is-loaded=true' },
+    );
+    await browser.switchFrame(iframe);
+    await $('my-component').waitForExist({ timeout: 30000 });
+    await browser.switchFrame(null);
   });
 
   afterEach(async () => {

--- a/tests/wdio.conf-lazy.ts
+++ b/tests/wdio.conf-lazy.ts
@@ -53,7 +53,7 @@ export const config: WebdriverIO.Config = {
   // and 30 processes will get spawned. The property handles how many capabilities
   // from the same test should run tests.
   //
-  maxInstances: 10,
+  maxInstances: 1,
   //
   // If you have trouble getting all important capabilities together, check out the
   // Sauce Labs platform configurator - a great tool to configure your capabilities:
@@ -161,6 +161,7 @@ export const config: WebdriverIO.Config = {
    * @param {Array.<Object>} capabilities list of capabilities details
    */
   onPrepare: function () {
+    process.env.STENCIL_HMR_PACKAGE = 'example-lazy';
     storybookProcess = cp.spawn('pnpm', ['dev.example-lazy'], {
       stdio: ['inherit', 'pipe', 'inherit'],
       cwd: path.resolve(__dirname, '..'),

--- a/tests/wdio.conf.ts
+++ b/tests/wdio.conf.ts
@@ -53,7 +53,7 @@ export const config: WebdriverIO.Config = {
   // and 30 processes will get spawned. The property handles how many capabilities
   // from the same test should run tests.
   //
-  maxInstances: 10,
+  maxInstances: 1,
   //
   // If you have trouble getting all important capabilities together, check out the
   // Sauce Labs platform configurator - a great tool to configure your capabilities:
@@ -161,6 +161,7 @@ export const config: WebdriverIO.Config = {
    * @param {Array.<Object>} capabilities list of capabilities details
    */
   onPrepare: function () {
+    process.env.STENCIL_HMR_PACKAGE = 'example';
     storybookProcess = cp.spawn('pnpm', ['dev.example'], {
       stdio: ['inherit', 'pipe', 'inherit'],
       cwd: path.resolve(__dirname, '..'),


### PR DESCRIPTION
## Summary

Storybook's Vite-based preview can't HMR Stencil components in place — `customElements.define()` is permanent, so swapping in a fresh class throws and the previous symptoms ("Failed to fetch dynamically imported module" / "Stencil component not found" / stale render). This PR makes the dev experience reliably auto-refresh on every component edit, for both eager (direct-import) and lazy (`defineCustomElements()`) example apps, including the Docs view.

### What changed

- **`packages/plugin/src/preset.ts`**: New dev-only Vite plugin (`stencilPreviewReloadPlugin`) that fires a custom `stencil:reload` HMR event whenever a component `.tsx` is edited.
  - **Eager**: hooked into `transform` so we reload after `unplugin-stencil` has run.
  - **Lazy**: handled in `configureServer` — manually invoke `unplugin-stencil`'s transform, poll `dist/esm/*.entry.js` mtimes (Stencil's compile flushes asynchronously), invalidate Vite's module cache for those files, then reload.
  - Tell Vite to `server.watch.ignored` this plugin's own `dist/`. Otherwise `tsdown --watch` rewrites trigger a Vite re-optimization that bumps the React/optimized-deps `?v=` cache key mid-session and produces the `TypeError: Cannot read properties of null (reading 'useEffect')` in `<DocsContainer>`.
- **`packages/plugin/src/entry-preview.ts`**: subscribe to `stencil:reload` and call `location.reload()`.
- **`packages/plugin/src/render.ts`**: after HMR the component class reference changes but the tag is still registered, so fall back to `component.is` when `customElements.getName(component)` returns `null` instead of throwing.
- **`packages/plugin/tsdown.config.ts`**: skip the `clean` step in watch mode so `dist/` stays available across rebuilds.
- **`packages/plugin/src/typing.d.ts`**: minimal `ImportMeta.hot` typing for the preview entry.
- **`packages/example*/.storybook`**: typed configs, simplified `staticDirs`, and `defineCustomElements()` without the now-unnecessary `resourcesUrl` override.
- **`tests/hmr.e2e.ts` (new)** + **`tests/wdio.conf.ts`** / **`tests/wdio.conf-lazy.ts`**: new e2e spec exercises the full edit→reload→restore cycle for both example apps; wdio configs select the right package via `STENCIL_HMR_PACKAGE`, run with `maxInstances: 1` so the file-mutation tests don't race the snapshot tests, point lazy at `localhost:6007`, and spawn `pnpm dev.example*` from the workspace root.

## Test plan

- [x] `pnpm test` (eager) — 7/7 pass, including new HMR specs.
- [x] `pnpm test.example-lazy` (lazy) — 7/7 pass, including new HMR specs.
- [x] Manual: edit `packages/example/src/components/my-component/my-component.tsx`, see iframe live-update at `http://localhost:6006/?path=/story/mycomponent--primary` and `http://localhost:6006/?path=/docs/mycomponent--docs`.
- [x] Manual: same for `packages/example-lazy` at port 6007.
- [x] Manual: trigger a `tsdown` rebuild while the docs page is open — no more `useEffect` null / `[vite] Failed to reload` cascade, no React duplication.