### PR TITLE
feat(plugin): hot-reload Stencil style files via unplugin-stencil 0.5.x

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -64,12 +64,12 @@
     "build": "tsdown"
   },
   "dependencies": {
+    "@stencil-community/unplugin-stencil": "^0.5.2",
     "@storybook/builder-vite": "^10.0.0",
     "@storybook/global": "^5.0.0",
     "@storybook/html": "^10.0.0",
     "preact-render-to-string": "^6.5.13",
-    "react-docgen-typescript": "^2.4.0",
-    "unplugin-stencil": "^0.4.1"
+    "react-docgen-typescript": "^2.4.0"
   },
   "peerDependencies": {
     "@stencil/core": "^4.30.0",

--- a/packages/plugin/src/preset.ts
+++ b/packages/plugin/src/preset.ts
@@ -2,10 +2,11 @@
  * we can't prefix the Node.js imports with `node:` because it will break
  * within Storybook due to its Vite setup.
  */
-import { existsSync, readdirSync, readFileSync, statSync } from 'fs';
+import { readFileSync, utimesSync } from 'fs';
 import { createRequire } from 'module';
-import { dirname, join, sep } from 'path';
-import stencil from 'unplugin-stencil/vite';
+import { dirname, join, resolve, sep } from 'path';
+import { getComponentStyleDependencies, stencilBuildEvents } from '@stencil-community/unplugin-stencil';
+import stencil from '@stencil-community/unplugin-stencil/vite';
 import { fileURLToPath } from 'url';
 import type { HmrContext, Plugin, ViteDevServer } from 'vite';
 import { mergeConfig } from 'vite';
@@ -17,6 +18,8 @@ const getAbsolutePath = <I extends string>(input: I): I => dirname(require.resol
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const renderer = join(__dirname, 'entry-preview.js');
+
+const UNPLUGIN_STENCIL_NAME = '@stencil-community/unplugin-stencil';
 
 export const core: StorybookConfig['core'] = {
   builder: join(getAbsolutePath('@storybook/builder-vite'), 'dist', 'index.js'),
@@ -68,9 +71,16 @@ export const viteFinal: StorybookConfig['viteFinal'] = async (defaultConfig, { c
  *
  * - Eager: the .tsx is in Vite's graph; our `transform` hook fires after
  *   unplugin-stencil and emits the reload.
- * - Lazy: the .tsx isn't imported, so we run unplugin-stencil ourselves, wait
- *   for `dist/esm/*.entry.js` to be rewritten (Stencil's build is async), then
- *   reload.
+ * - Lazy: the .tsx isn't imported, so we run unplugin-stencil ourselves, then
+ *   reload once `@stencil-community/unplugin-stencil` reports the build
+ *   finished (its `stencilBuildEvents` emitter, instead of polling dist/esm).
+ * - Styles: `@stencil-community/unplugin-stencil` exposes a `style → component`
+ *   map built from each component's `@Component` decorator (AST-parsed, covers
+ *   `styleUrl`, `styleUrls` array, and `styleUrls` mode object). When a tracked
+ *   style file changes we touch every dependent `.tsx` so the eager/lazy paths
+ *   above pick up the rebuild.
+ * - Global style: the same package resolves `stencil.config#globalStyle`; when
+ *   it changes we touch every known component `.tsx`.
  */
 function stencilPreviewReloadPlugin(): Plugin {
   let devServer: ViteDevServer | undefined;
@@ -83,40 +93,81 @@ function stencilPreviewReloadPlugin(): Plugin {
   // Match dist/esm module ids on both POSIX and Windows.
   const distEsmFragment = `${sep}dist${sep}esm${sep}`;
 
+  const isComponentSource = (id: string): boolean =>
+    id.endsWith('.tsx') &&
+    !id.endsWith('.stories.tsx') &&
+    !id.includes(`${sep}node_modules${sep}`) &&
+    !id.includes(`${sep}.storybook${sep}`);
+
+  // dist/esm lives outside Vite's watched root, so its module cache never
+  // invalidates on its own. Drop it before reloading.
+  const invalidateDistEsm = (server: ViteDevServer): void => {
+    for (const cached of server.moduleGraph.idToModuleMap.values()) {
+      if (cached.id && cached.id.includes(distEsmFragment) && cached.id.endsWith('.js')) {
+        server.moduleGraph.invalidateModule(cached);
+      }
+    }
+  };
+
+  // Touch a file's mtime so unplugin-stencil recompiles it. The resulting
+  // `change` event re-enters the watcher handler and rides the eager/lazy path.
+  const touch = (file: string): void => {
+    try {
+      const now = new Date();
+      utimesSync(file, now, now);
+    } catch {
+      // ignore: best-effort touch
+    }
+  };
+
   return {
     name: 'stencil-preview-reload',
 
     configureServer(server) {
       devServer = server;
-      const distDir = join(server.config.root, 'dist', 'esm');
 
-      const snapshotMtimes = (): Record<string, number> => {
-        if (!existsSync(distDir)) return {};
-        const out: Record<string, number> = {};
-        for (const f of readdirSync(distDir)) {
-          if (!f.endsWith('.entry.js')) continue;
-          try {
-            out[f] = statSync(join(distDir, f)).mtimeMs;
-          } catch {
-            // file may be removed mid-scan
-          }
-        }
-        return out;
-      };
+      // When unplugin-stencil finishes a (project-wide) Stencil build, the
+      // fresh dist/esm chunks are on disk but Vite still has the old versions
+      // cached. If we kicked a lazy rebuild, invalidate + reload now.
+      stencilBuildEvents.on('buildFinished', () => {
+        if (!lazyBuildPending || !devServer) return;
+        lazyBuildPending = false;
+        invalidateDistEsm(devServer);
+        sendReload(devServer);
+      });
 
       server.watcher.on('change', async (file: string) => {
+        // unplugin-stencil seeds this map at buildStart, so it's populated from
+        // the first watcher event for eager, lazy, and globalStyle alike.
+        const { byStyle, byComponent, globalStyle } = getComponentStyleDependencies();
+        const resolved = resolve(file);
+
+        // Global style: baked into every component, so touch every component
+        // we know about and let the eager/lazy paths reload.
+        if (globalStyle && resolved === globalStyle) {
+          for (const componentId of byComponent.keys()) touch(componentId);
+          return;
+        }
+
+        // Component-style change: re-route to every dependent .tsx. Each touch
+        // produces a fresh `change` event that flows through the logic below.
+        const dependents = byStyle.get(resolved);
+        if (dependents && dependents.size > 0) {
+          for (const componentId of dependents) touch(componentId);
+          return;
+        }
+
         if (!file.endsWith('.tsx') || file.endsWith('.stories.tsx')) return;
 
         const mod = server.moduleGraph.getModuleById(file);
         // Eager components are handled by the `transform` hook below.
         if (mod && mod.importers.size > 0) return;
 
-        // Lazy: trigger Stencil's build manually, then poll mtimes since
-        // unplugin-stencil's transform resolves before the build flushes to disk.
-        const stencilPlugin = server.config.plugins.find((p) => p.name === 'unplugin-stencil');
+        // Lazy: trigger Stencil's build manually. unplugin-stencil's transform
+        // resolves before the build flushes to disk, so we set a flag and wait
+        // for `stencilBuildEvents.buildFinished` (above) to do the reload.
+        const stencilPlugin = server.config.plugins.find((p) => p.name === UNPLUGIN_STENCIL_NAME);
         if (!stencilPlugin || typeof stencilPlugin.transform !== 'function') return;
-
-        const before = snapshotMtimes();
 
         lazyBuildPending = true;
         try {
@@ -124,33 +175,7 @@ function stencilPreviewReloadPlugin(): Plugin {
           await (stencilPlugin.transform as any).call({ resolve: (): null => null }, code, file);
         } catch {
           lazyBuildPending = false;
-          return;
         }
-
-        const deadline = Date.now() + 5000;
-        const tick = (): void => {
-          if (!lazyBuildPending) return;
-          const after = snapshotMtimes();
-          const changed = Object.keys(after).some((f) => !(f in before) || after[f] > before[f]);
-          if (changed) {
-            lazyBuildPending = false;
-            // dist/esm lives outside Vite's watched root, so its module cache
-            // never invalidates on its own. Drop it before reloading.
-            for (const cached of server.moduleGraph.idToModuleMap.values()) {
-              if (cached.id && cached.id.includes(distEsmFragment) && cached.id.endsWith('.js')) {
-                server.moduleGraph.invalidateModule(cached);
-              }
-            }
-            sendReload(server);
-            return;
-          }
-          if (Date.now() > deadline) {
-            lazyBuildPending = false;
-            return;
-          }
-          setTimeout(tick, 50);
-        };
-        tick();
       });
     },
 
@@ -166,7 +191,8 @@ function stencilPreviewReloadPlugin(): Plugin {
 
     async transform(_code, id) {
       if (!devServer) return;
-      if (!id.endsWith('.tsx') || id.endsWith('.stories.tsx')) return;
+      const cleanId = id.split('?')[0];
+      if (!isComponentSource(cleanId)) return;
       if (lazyBuildPending) return;
       sendReload(devServer);
     },

--- a/packages/plugin/tsdown.config.ts
+++ b/packages/plugin/tsdown.config.ts
@@ -20,6 +20,13 @@ export default defineConfig({
     'fsevents', // macOS file watching native module
     'esbuild', // Contains native binaries
     'vite', // May contain native dependencies
+    // Stencil packages ship their own ESM/CJS builds with native-ish Node
+    // interop (e.g. `@stencil/core/sys/node`'s default export). Bundling them
+    // mangles that interop and makes `nodeApi` undefined at runtime, so always
+    // resolve them from node_modules instead of inlining. Match subpath
+    // imports too (e.g. `@stencil-community/unplugin-stencil/vite`).
+    /^@stencil\/core(\/.*)?$/,
+    /^@stencil-community\/unplugin-stencil(\/.*)?$/,
   ],
   outDir: './dist',
   format: ['esm', 'cjs'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,9 @@ importers:
 
   packages/plugin:
     dependencies:
+      '@stencil-community/unplugin-stencil':
+        specifier: ^0.5.2
+        version: 0.5.2(@stencil/core@4.33.1)(esbuild@0.25.2)(vite@6.3.5(@types/node@22.15.3)(jiti@2.4.2)(tsx@4.19.3))
       '@storybook/builder-vite':
         specifier: ^10.0.0
         version: 10.2.17(esbuild@0.25.2)(storybook@10.2.17(@testing-library/dom@10.4.0)(prettier@3.5.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite@6.3.5(@types/node@22.15.3)(jiti@2.4.2)(tsx@4.19.3))
@@ -140,9 +143,6 @@ importers:
       storybook:
         specifier: ^10.0.0
         version: 10.2.17(@testing-library/dom@10.4.0)(prettier@3.5.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      unplugin-stencil:
-        specifier: ^0.4.1
-        version: 0.4.1(@stencil/core@4.33.1)(esbuild@0.25.2)(vite@6.3.5(@types/node@22.15.3)(jiti@2.4.2)(tsx@4.19.3))
     devDependencies:
       '@stencil/core':
         specifier: ^4.33.1
@@ -916,6 +916,30 @@ packages:
 
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
+
+  '@stencil-community/unplugin-stencil@0.5.2':
+    resolution: {integrity: sha512-5MN8Kbovtv7Rz2tj4u+V+E+4KYI98aj1pHBWKNxtzFYaR63ONa3KZ7BgIezzt6RZiHZ9z1WrUpnRF6x7ZiRCTg==}
+    peerDependencies:
+      '@nuxt/kit': ^3
+      '@nuxt/schema': ^3
+      '@stencil/core': ^4.29.3
+      esbuild: '*'
+      rollup: ^3
+      vite: '>=3'
+      webpack: ^4 || ^5
+    peerDependenciesMeta:
+      '@nuxt/kit':
+        optional: true
+      '@nuxt/schema':
+        optional: true
+      esbuild:
+        optional: true
+      rollup:
+        optional: true
+      vite:
+        optional: true
+      webpack:
+        optional: true
 
   '@stencil/core@4.33.1':
     resolution: {integrity: sha512-12k9xhAJBkpg598it+NRmaYIdEe6TSnsL/v6/KRXDcUyTK11VYwZQej2eHnMWtqot+znJ+GNTqb5YbiXi+5Low==}
@@ -3232,30 +3256,6 @@ packages:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
 
-  unplugin-stencil@0.4.1:
-    resolution: {integrity: sha512-GeXXfzbIOtNrC6QQOmiWsxkDeuA+dWv8EicphfM2iUSsO5yQ+FnMdwlXIiqCi5VbnnKmXP7gnRdFUHwRdAralA==}
-    peerDependencies:
-      '@nuxt/kit': ^3
-      '@nuxt/schema': ^3
-      '@stencil/core': ^4.29.3
-      esbuild: '*'
-      rollup: ^3
-      vite: '>=3'
-      webpack: ^4 || ^5
-    peerDependenciesMeta:
-      '@nuxt/kit':
-        optional: true
-      '@nuxt/schema':
-        optional: true
-      esbuild:
-        optional: true
-      rollup:
-        optional: true
-      vite:
-        optional: true
-      webpack:
-        optional: true
-
   unplugin@2.3.10:
     resolution: {integrity: sha512-6NCPkv1ClwH+/BGE9QeoTIl09nuiAt0gS28nn1PvYXsGKRwM2TCbFA2QiilmehPDTXIe684k4rZI1yl3A1PCUw==}
     engines: {node: '>=18.12.0'}
@@ -4257,6 +4257,16 @@ snapshots:
   '@sinonjs/fake-timers@10.3.0':
     dependencies:
       '@sinonjs/commons': 3.0.1
+
+  '@stencil-community/unplugin-stencil@0.5.2(@stencil/core@4.33.1)(esbuild@0.25.2)(vite@6.3.5(@types/node@22.15.3)(jiti@2.4.2)(tsx@4.19.3))':
+    dependencies:
+      '@stencil/core': 4.33.1
+      mlly: 1.8.0
+      typescript: 5.8.3
+      unplugin: 2.3.10
+    optionalDependencies:
+      esbuild: 0.25.2
+      vite: 6.3.5(@types/node@22.15.3)(jiti@2.4.2)(tsx@4.19.3)
 
   '@stencil/core@4.33.1':
     optionalDependencies:
@@ -6939,15 +6949,6 @@ snapshots:
   undici@6.21.2: {}
 
   unicorn-magic@0.3.0: {}
-
-  unplugin-stencil@0.4.1(@stencil/core@4.33.1)(esbuild@0.25.2)(vite@6.3.5(@types/node@22.15.3)(jiti@2.4.2)(tsx@4.19.3)):
-    dependencies:
-      '@stencil/core': 4.33.1
-      mlly: 1.8.0
-      unplugin: 2.3.10
-    optionalDependencies:
-      esbuild: 0.25.2
-      vite: 6.3.5(@types/node@22.15.3)(jiti@2.4.2)(tsx@4.19.3)
 
   unplugin@2.3.10:
     dependencies:

--- a/tests/hmr.e2e.ts
+++ b/tests/hmr.e2e.ts
@@ -17,6 +17,16 @@ const COMPONENT_PATH = path.resolve(
   'my-component',
   'my-component.tsx',
 );
+const STYLE_PATH = path.resolve(
+  __dirname,
+  '..',
+  'packages',
+  PACKAGE,
+  'src',
+  'components',
+  'my-component',
+  'my-component.css',
+);
 
 const ORIGINAL_RENDER = `    return <div>Hello, World! I'm {this.getText()}</div>;`;
 // Matches any prior HMR mutation of the render line so we can self-heal a file
@@ -49,11 +59,31 @@ async function readMyComponentText() {
   });
 }
 
+async function readHostDisplay() {
+  await browser.switchFrame(null);
+  await browser.switchFrame(() => Boolean(document.querySelector('my-component')));
+  const el = await $('my-component');
+  await el.waitForExist({ timeout: 15000 });
+  await browser.waitUntil(
+    async () => {
+      const cls = await $('my-component').getAttribute('class');
+      return typeof cls === 'string' && cls.split(/\s+/).includes('hydrated');
+    },
+    { timeout: 15000, interval: 200, timeoutMsg: 'my-component never reached the `hydrated` state' },
+  );
+  return browser.execute(() => {
+    const host = document.querySelector('my-component');
+    return host ? getComputedStyle(host).display : '';
+  });
+}
+
 describe(`StencilJS Storybook HMR (${PACKAGE})`, () => {
   let originalSource: string | undefined;
+  let originalStyle: string | undefined;
 
   before(async () => {
     const onDisk = fs.readFileSync(COMPONENT_PATH, 'utf-8');
+    originalStyle = fs.readFileSync(STYLE_PATH, 'utf-8');
 
     if (onDisk.includes(ORIGINAL_RENDER)) {
       originalSource = onDisk;
@@ -76,10 +106,11 @@ describe(`StencilJS Storybook HMR (${PACKAGE})`, () => {
     // Storybook flips this to "true" only once the preview iframe has booted
     // and a story is rendered. Without this we can switch into a still-empty
     // iframe and time out waiting for <my-component>.
-    await browser.waitUntil(
-      async () => (await iframe.getAttribute('data-is-loaded')) === 'true',
-      { timeout: 60000, interval: 250, timeoutMsg: 'Storybook preview iframe never reached data-is-loaded=true' },
-    );
+    await browser.waitUntil(async () => (await iframe.getAttribute('data-is-loaded')) === 'true', {
+      timeout: 60000,
+      interval: 250,
+      timeoutMsg: 'Storybook preview iframe never reached data-is-loaded=true',
+    });
     await browser.switchFrame(iframe);
     await $('my-component').waitForExist({ timeout: 30000 });
     await browser.switchFrame(null);
@@ -92,6 +123,9 @@ describe(`StencilJS Storybook HMR (${PACKAGE})`, () => {
   after(() => {
     if (originalSource !== undefined) {
       fs.writeFileSync(COMPONENT_PATH, originalSource, 'utf-8');
+    }
+    if (originalStyle !== undefined) {
+      fs.writeFileSync(STYLE_PATH, originalStyle, 'utf-8');
     }
   });
 
@@ -144,6 +178,64 @@ describe(`StencilJS Storybook HMR (${PACKAGE})`, () => {
         timeout: 60000,
         interval: 1000,
         timeoutMsg: 'Component did not return to the original render after restoring the file',
+      },
+    );
+  });
+
+  it('reloads the preview iframe when the component stylesheet changes', async () => {
+    // Baseline: the canonical stylesheet sets `:host { display: block }`.
+    await browser.waitUntil(
+      async () => {
+        try {
+          return (await readHostDisplay()) === 'block';
+        } catch {
+          return false;
+        }
+      },
+      { timeout: 30000, interval: 1000, timeoutMsg: 'Host did not start with display: block' },
+    );
+
+    const updatedStyle = (originalStyle as string).replace('display: block;', 'display: inline-block;');
+    if (updatedStyle === originalStyle) {
+      throw new Error('Failed to produce an updated stylesheet for style HMR test.');
+    }
+
+    fs.writeFileSync(STYLE_PATH, updatedStyle, 'utf-8');
+
+    try {
+      await browser.waitUntil(
+        async () => {
+          try {
+            return (await readHostDisplay()) === 'inline-block';
+          } catch {
+            return false;
+          }
+        },
+        {
+          // Style edits re-route through the dependent component, which re-runs
+          // the Stencil compiler, so allow extra time.
+          timeout: 60000,
+          interval: 1000,
+          timeoutMsg: 'Host never picked up the edited stylesheet (display: inline-block)',
+        },
+      );
+    } finally {
+      fs.writeFileSync(STYLE_PATH, originalStyle as string, 'utf-8');
+    }
+
+    // After restoring the stylesheet the preview should reload back to block.
+    await browser.waitUntil(
+      async () => {
+        try {
+          return (await readHostDisplay()) === 'block';
+        } catch {
+          return false;
+        }
+      },
+      {
+        timeout: 60000,
+        interval: 1000,
+        timeoutMsg: 'Host did not return to display: block after restoring the stylesheet',
       },
     );
   });


### PR DESCRIPTION
## Summary

- Stylesheet edits now trigger preview HMR. The preset adopts `@stencil-community/unplugin-stencil` 0.5.2 and uses `getComponentStyleDependencies()` to map style files back to their components (`styleUrl`, `styleUrls` array, `styleUrls` mode object, and `stencil.config#globalStyle`), touching each dependent `.tsx` so the existing eager/lazy reload paths fire.
- Reloads now key off the package's `stencilBuildEvents` emitter instead of polling `dist/esm` mtimes.
- `@stencil-community/unplugin-stencil` moved to plugin `dependencies` (`^0.5.2`); `@stencil/core` and the unplugin are externalized in `tsdown` so their ESM/CJS default-export interop isn't mangled by bundling (was causing `nodeApi` undefined at runtime).
- Added a project `.npmrc` pinning the public npm registry so installs resolve from `registry.npmjs.org`.

## Test plan

- [ ] `pnpm test` (wdio e2e) — eager + lazy configs green, including the new stylesheet HMR case in `tests/hmr.e2e.ts`
- [ ] Manually edit a component `.css`/`.scss` in the example app and confirm the Storybook preview updates without a full reload
- [ ] Edit `globalStyle` and confirm all components refresh