### PR TITLE
fix(plugin): reload preview on external Stencil builds via staticDirs

### DIFF
--- a/packages/plugin/src/preset.ts
+++ b/packages/plugin/src/preset.ts
@@ -46,6 +46,13 @@ export const viteFinal: StorybookConfig['viteFinal'] = async (defaultConfig, opt
           external: ['@stencil/core'],
         },
       },
+      // Pre-bundle the deps Storybook/Stencil otherwise discover lazily on the
+      // first preview load. Without this Vite runs a dep re-optimization mid-
+      // session ("optimized dependencies changed. reloading") that tears down
+      // the iframe right as the first story renders.
+      optimizeDeps: {
+        include: ['storybook/internal/docs-tools', '@stencil/core', '@stencil/core/internal/client'],
+      },
       // Don't let Vite watch this plugin's own `dist/`. `tsdown --watch`
       // rewrites those files during plugin development; if Vite picks the
       // change up it re-optimizes deps, bumping the React chunk hash and

--- a/packages/plugin/src/preset.ts
+++ b/packages/plugin/src/preset.ts
@@ -26,7 +26,8 @@ export const core: StorybookConfig['core'] = {
   renderer,
 };
 
-export const viteFinal: StorybookConfig['viteFinal'] = async (defaultConfig, { configType }) => {
+export const viteFinal: StorybookConfig['viteFinal'] = async (defaultConfig, options) => {
+  const { configType } = options;
   const config = mergeConfig(defaultConfig, {
     build: {
       target: 'es2020',
@@ -38,6 +39,12 @@ export const viteFinal: StorybookConfig['viteFinal'] = async (defaultConfig, { c
     ],
   });
   if (configType === 'DEVELOPMENT') {
+    // Resolve the absolute `staticDirs` directories. For external-build / lazy
+    // consumers these hold a prebuilt Stencil bundle (e.g.
+    // `staticDirs: ['../dist/esm']` fed by a separate `stencil build --watch`).
+    // They're served as static assets, so Vite never tracks them as modules and
+    // HMR never fires on a rebuild. The reload plugin watches them directly.
+    const staticDirs = await resolveStaticDirs(options);
     return mergeConfig(config, {
       build: {
         rollupOptions: {
@@ -54,12 +61,45 @@ export const viteFinal: StorybookConfig['viteFinal'] = async (defaultConfig, { c
           ignored: [join(__dirname, '**')],
         },
       },
-      plugins: [stencilPreviewReloadPlugin()],
+      plugins: [stencilPreviewReloadPlugin(staticDirs)],
     });
   }
 
   return config;
 };
+
+/**
+ * Resolve the absolute directories declared via Storybook `staticDirs`.
+ *
+ * For external-build / lazy consumers these point at a prebuilt Stencil bundle
+ * (e.g. `staticDirs: ['../dist/esm']`) produced by a separate
+ * `stencil build --watch`. `staticDirs` entries are relative to the Storybook
+ * config dir; we resolve them so the reload plugin can watch them directly.
+ */
+async function resolveStaticDirs(options: {
+  configDir?: string;
+  presets?: { apply: (extension: 'staticDirs', config?: unknown, args?: unknown) => Promise<unknown> };
+}): Promise<string[]> {
+  const configDir = options.configDir;
+  if (!configDir || !options.presets) return [];
+
+  let staticDirs: unknown;
+  try {
+    staticDirs = await options.presets.apply('staticDirs');
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(staticDirs)) return [];
+
+  const dirs = new Set<string>();
+  for (const entry of staticDirs) {
+    // `staticDirs` is `(string | { from: string; to: string })[]`.
+    const from = typeof entry === 'string' ? entry : entry && (entry as { from?: string }).from;
+    if (typeof from !== 'string' || from.length === 0) continue;
+    dirs.add(resolve(configDir, from));
+  }
+  return [...dirs];
+}
 
 /**
  * Forces a full preview reload when a Stencil component changes.
@@ -81,8 +121,17 @@ export const viteFinal: StorybookConfig['viteFinal'] = async (defaultConfig, { c
  *   above pick up the rebuild.
  * - Global style: the same package resolves `stencil.config#globalStyle`; when
  *   it changes we touch every known component `.tsx`.
+ * - External build: consumers that run `stencil build --watch` separately and
+ *   serve the prebuilt output via `staticDirs: ['../dist/esm']` never import a
+ *   component `.tsx` into Vite's graph, so unplugin-stencil never compiles and
+ *   the paths above can't fire. For those we watch the `staticDirs` `*.js`
+ *   files directly and reload when the external Stencil rebuild rewrites them.
+ *   See `watchStaticDirs`.
+ *
+ * @param staticDirs absolute Storybook `staticDirs` directories to watch for
+ *   externally-built output.
  */
-function stencilPreviewReloadPlugin(): Plugin {
+function stencilPreviewReloadPlugin(staticDirs: string[] = []): Plugin {
   let devServer: ViteDevServer | undefined;
   let lazyBuildPending = false;
 
@@ -120,11 +169,38 @@ function stencilPreviewReloadPlugin(): Plugin {
     }
   };
 
+  // Absolute `staticDirs`, normalized with a trailing separator so prefix
+  // matches don't treat `dist/esmx` as inside `dist/esm`.
+  const staticDirPrefixes = staticDirs.map((dir) => (dir.endsWith(sep) ? dir : `${dir}${sep}`));
+
+  const isInStaticDir = (file: string): boolean => staticDirPrefixes.some((prefix) => file.startsWith(prefix));
+
+  // A single external `stencil build --watch` rebuild rewrites many chunks at
+  // once; debounce so we reload once per rebuild instead of once per file.
+  let staticReloadTimer: ReturnType<typeof setTimeout> | undefined;
+  const scheduleStaticReload = (server: ViteDevServer): void => {
+    if (staticReloadTimer) clearTimeout(staticReloadTimer);
+    staticReloadTimer = setTimeout(() => {
+      staticReloadTimer = undefined;
+      invalidateDistEsm(server);
+      sendReload(server);
+    }, 150);
+  };
+
   return {
     name: 'stencil-preview-reload',
 
     configureServer(server) {
       devServer = server;
+
+      // External-build / lazy consumers serve a prebuilt Stencil bundle from
+      // `staticDirs` (fed by a separate `stencil build --watch`). That output
+      // lives outside Vite's root and isn't in the module graph, so Vite won't
+      // watch it on its own — register the dirs explicitly so chunk rewrites
+      // emit `change` events we can react to.
+      if (staticDirPrefixes.length > 0) {
+        server.watcher.add(staticDirs);
+      }
 
       // When unplugin-stencil finishes a (project-wide) Stencil build, the
       // fresh dist/esm chunks are on disk but Vite still has the old versions
@@ -137,6 +213,16 @@ function stencilPreviewReloadPlugin(): Plugin {
       });
 
       server.watcher.on('change', async (file: string) => {
+        // External build: a watched `staticDirs` JS file (e.g. a rebuilt
+        // `dist/esm/*.entry.js`) changed. The component .tsx was never in
+        // Vite's graph, so the eager/lazy paths below can't fire — reload
+        // directly (debounced, since one rebuild rewrites many chunks). Skip
+        // while a lazy in-graph rebuild is pending so we don't double-reload.
+        if (file.endsWith('.js') && isInStaticDir(file)) {
+          if (!lazyBuildPending) scheduleStaticReload(server);
+          return;
+        }
+
         // unplugin-stencil seeds this map at buildStart, so it's populated from
         // the first watcher event for eager, lazy, and globalStyle alike.
         const { byStyle, byComponent, globalStyle } = getComponentStyleDependencies();

--- a/packages/plugin/src/preset.ts
+++ b/packages/plugin/src/preset.ts
@@ -27,7 +27,6 @@ export const core: StorybookConfig['core'] = {
 };
 
 export const viteFinal: StorybookConfig['viteFinal'] = async (defaultConfig, options) => {
-  const { configType } = options;
   const config = mergeConfig(defaultConfig, {
     build: {
       target: 'es2020',
@@ -38,12 +37,8 @@ export const viteFinal: StorybookConfig['viteFinal'] = async (defaultConfig, opt
       }),
     ],
   });
-  if (configType === 'DEVELOPMENT') {
-    // Resolve the absolute `staticDirs` directories. For external-build / lazy
-    // consumers these hold a prebuilt Stencil bundle (e.g.
-    // `staticDirs: ['../dist/esm']` fed by a separate `stencil build --watch`).
-    // They're served as static assets, so Vite never tracks them as modules and
-    // HMR never fires on a rebuild. The reload plugin watches them directly.
+  if (options.configType === 'DEVELOPMENT') {
+    // Watch the externally-built Stencil output served via `staticDirs`.
     const staticDirs = await resolveStaticDirs(options);
     return mergeConfig(config, {
       build: {
@@ -69,12 +64,8 @@ export const viteFinal: StorybookConfig['viteFinal'] = async (defaultConfig, opt
 };
 
 /**
- * Resolve the absolute directories declared via Storybook `staticDirs`.
- *
- * For external-build / lazy consumers these point at a prebuilt Stencil bundle
- * (e.g. `staticDirs: ['../dist/esm']`) produced by a separate
- * `stencil build --watch`. `staticDirs` entries are relative to the Storybook
- * config dir; we resolve them so the reload plugin can watch them directly.
+ * Resolve Storybook `staticDirs` to absolute paths. Entries are relative to the
+ * config dir and may be a string or `{ from, to }`.
  */
 async function resolveStaticDirs(options: {
   configDir?: string;
@@ -93,7 +84,6 @@ async function resolveStaticDirs(options: {
 
   const dirs = new Set<string>();
   for (const entry of staticDirs) {
-    // `staticDirs` is `(string | { from: string; to: string })[]`.
     const from = typeof entry === 'string' ? entry : entry && (entry as { from?: string }).from;
     if (typeof from !== 'string' || from.length === 0) continue;
     dirs.add(resolve(configDir, from));
@@ -121,15 +111,12 @@ async function resolveStaticDirs(options: {
  *   above pick up the rebuild.
  * - Global style: the same package resolves `stencil.config#globalStyle`; when
  *   it changes we touch every known component `.tsx`.
- * - External build: consumers that run `stencil build --watch` separately and
- *   serve the prebuilt output via `staticDirs: ['../dist/esm']` never import a
- *   component `.tsx` into Vite's graph, so unplugin-stencil never compiles and
- *   the paths above can't fire. For those we watch the `staticDirs` `*.js`
- *   files directly and reload when the external Stencil rebuild rewrites them.
- *   See `watchStaticDirs`.
+ * - External build: consumers running `stencil build --watch` separately serve
+ *   prebuilt output via `staticDirs` and never import the `.tsx` into Vite's
+ *   graph, so the paths above can't fire. We watch those dirs and reload when
+ *   their `*.js` files change.
  *
- * @param staticDirs absolute Storybook `staticDirs` directories to watch for
- *   externally-built output.
+ * @param staticDirs absolute `staticDirs` to watch for externally-built output.
  */
 function stencilPreviewReloadPlugin(staticDirs: string[] = []): Plugin {
   let devServer: ViteDevServer | undefined;
@@ -169,14 +156,13 @@ function stencilPreviewReloadPlugin(staticDirs: string[] = []): Plugin {
     }
   };
 
-  // Absolute `staticDirs`, normalized with a trailing separator so prefix
-  // matches don't treat `dist/esmx` as inside `dist/esm`.
+  // Normalize with a trailing separator so `dist/esmx` isn't matched as
+  // inside `dist/esm`.
   const staticDirPrefixes = staticDirs.map((dir) => (dir.endsWith(sep) ? dir : `${dir}${sep}`));
 
   const isInStaticDir = (file: string): boolean => staticDirPrefixes.some((prefix) => file.startsWith(prefix));
 
-  // A single external `stencil build --watch` rebuild rewrites many chunks at
-  // once; debounce so we reload once per rebuild instead of once per file.
+  // One external rebuild rewrites many chunks; debounce to a single reload.
   let staticReloadTimer: ReturnType<typeof setTimeout> | undefined;
   const scheduleStaticReload = (server: ViteDevServer): void => {
     if (staticReloadTimer) clearTimeout(staticReloadTimer);
@@ -193,11 +179,8 @@ function stencilPreviewReloadPlugin(staticDirs: string[] = []): Plugin {
     configureServer(server) {
       devServer = server;
 
-      // External-build / lazy consumers serve a prebuilt Stencil bundle from
-      // `staticDirs` (fed by a separate `stencil build --watch`). That output
-      // lives outside Vite's root and isn't in the module graph, so Vite won't
-      // watch it on its own — register the dirs explicitly so chunk rewrites
-      // emit `change` events we can react to.
+      // `staticDirs` live outside Vite's root, so register them explicitly to
+      // get `change` events when an external rebuild rewrites chunks.
       if (staticDirPrefixes.length > 0) {
         server.watcher.add(staticDirs);
       }
@@ -213,11 +196,9 @@ function stencilPreviewReloadPlugin(staticDirs: string[] = []): Plugin {
       });
 
       server.watcher.on('change', async (file: string) => {
-        // External build: a watched `staticDirs` JS file (e.g. a rebuilt
-        // `dist/esm/*.entry.js`) changed. The component .tsx was never in
-        // Vite's graph, so the eager/lazy paths below can't fire — reload
-        // directly (debounced, since one rebuild rewrites many chunks). Skip
-        // while a lazy in-graph rebuild is pending so we don't double-reload.
+        // External build: a watched static-dir chunk changed. Reload directly
+        // (the `.tsx` isn't in the graph), but not while a lazy rebuild is
+        // pending, which reloads via `buildFinished` above.
         if (file.endsWith('.js') && isInStaticDir(file)) {
           if (!lazyBuildPending) scheduleStaticReload(server);
           return;

--- a/tests/hmr.e2e.ts
+++ b/tests/hmr.e2e.ts
@@ -111,8 +111,36 @@ describe(`StencilJS Storybook HMR (${PACKAGE})`, () => {
     }
 
     await browser.url(`/?path=/story/mycomponent--primary`);
-    await switchToPreviewIframe();
-    await $('my-component').waitForExist({ timeout: 30000 });
+    const iframe = $('#storybook-preview-iframe');
+    await iframe.waitForExist({ timeout: 30000 });
+    // Storybook flips this to "true" only once the preview iframe has booted
+    // and a story is rendered. Without this we can switch into a still-empty
+    // iframe and time out waiting for <my-component>.
+    await browser.waitUntil(async () => (await iframe.getAttribute('data-is-loaded')) === 'true', {
+      timeout: 60000,
+      interval: 250,
+      timeoutMsg: 'Storybook preview iframe never reached data-is-loaded=true',
+    });
+    // Vite can run a late dep-optimization pass ("optimized dependencies
+    // changed. reloading") right after the preview boots, which tears down the
+    // iframe mid-render. Re-enter the frame and re-query on each tick so a
+    // reload here doesn't leave us waiting on a stale, detached document.
+    await browser.waitUntil(
+      async () => {
+        try {
+          await browser.switchFrame(null);
+          await browser.switchFrame(() => Boolean(document.querySelector('my-component')));
+          return true;
+        } catch {
+          return false;
+        }
+      },
+      {
+        timeout: 30000,
+        interval: 500,
+        timeoutMsg: 'my-component never appeared in the preview iframe',
+      },
+    );
     await browser.switchFrame(null);
   });
 


### PR DESCRIPTION
## Summary

Two related fixes for the Stencil Storybook dev preview:

1. **HMR for externally-built Stencil** — reload the preview when a consumer builds Stencil via a separate `stencil build --watch` and serves the prebuilt output through Storybook `staticDirs` (e.g. `staticDirs: ['../dist/esm']`) with a lazy `defineCustomElements()` in `preview.tsx`.
2. **No spurious reload on first preview load** — pre-bundle the deps Storybook/Stencil otherwise discover lazily, so Vite doesn't run a mid-session dep re-optimization that tears down the iframe right as the first story renders.

## 1. External-build HMR

In the external-build / lazy setup, stories never import a component `.tsx` into Vite's module graph, so the injected `unplugin-stencil` never compiles the project and its dependency maps stay empty. On a rebuild the external `stencil --watch` rewrites `dist/esm/*.js`, but those are static assets Vite doesn't track as modules — so the existing eager / lazy / style reload paths in `stencilPreviewReloadPlugin` can't fire and the preview never reloads.

Changes in `packages/plugin/src/preset.ts`:

- Resolve the configured `staticDirs` to absolute paths in `viteFinal` (via `options.presets.apply('staticDirs')`, relative to `configDir`) and pass them to `stencilPreviewReloadPlugin`.
- Explicitly `server.watcher.add()` those dirs — `dist/esm` lives outside Vite's root, so chokidar won't watch it otherwise.
- On a `*.js` change inside a watched static dir, invalidate the cached `dist/esm` modules and send the existing `stencil:reload` event.
- Debounce the reload (one external rebuild rewrites many chunks), and skip it while a lazy in-graph rebuild is pending to avoid double reloads.

Auto-detected / opt-in: a no-op when no `staticDirs` are configured.

## 2. Pre-bundle deps to avoid mid-session reload

`storybook/internal/docs-tools`, `@stencil/core`, and `@stencil/core/internal/client` were discovered lazily on the first preview load, triggering Vite dep re-optimizations (`optimized dependencies changed. reloading`) that tore down the iframe as the first story rendered. This surfaced as a CI flake in the HMR e2e suite (the reload raced the initial `<my-component>` render) but also affects real users as a surprise full reload on first load.

- Add `optimizeDeps.include` for those deps so all optimization happens at startup and the preview renders once, without a reload.
- Harden the HMR e2e `before` hook (`tests/hmr.e2e.ts`) to re-enter the iframe and re-query across any reload, as defense-in-depth.

## Test plan

- [x] `example-lazy` (external `stencil build --watch` + `staticDirs: ['../dist/esm']`): preview renders with no startup reload; editing a component reloads the preview.
- [x] `example` (eager, in-graph): editing a component/style reloads once (no double-fire / regression).
- [x] No `reloading` messages observed in either suite after pre-bundling.
- [x] CI `build_and_test` green.