### PR TITLE
fix(plugin): correct argtype inference so URL param args apply to all controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+.pnpm-store
 packages/*/dist
 pnp.*
 .yarn/*

--- a/packages/plugin/src/docs/custom-elements.ts
+++ b/packages/plugin/src/docs/custom-elements.ts
@@ -137,7 +137,7 @@ const mapProps = (props: JsonDocsProp[]): ArgTypes =>
         type: { summary: prop.complexType?.original },
         defaultValue: { summary: prop.default },
       },
-      options: mapPropOptions(prop),
+      options: mapPropOptions(prop).length > 0 ? mapPropOptions(prop) : undefined,
       type: inferSBType(prop),
     };
 

--- a/packages/plugin/src/docs/infer-type.ts
+++ b/packages/plugin/src/docs/infer-type.ts
@@ -1,9 +1,9 @@
 import type { JsonDocsProp } from '@stencil/core/internal';
-import type { InputType, SBScalarType, SBType } from 'storybook/internal/types';
+import type { InputType, SBEnumType, SBScalarType, SBType } from 'storybook/internal/types';
 
 export const inferSBType = (prop: JsonDocsProp): SBType => {
   const scalarTypes: SBScalarType['name'][] = ['string', 'number', 'boolean', 'symbol'];
-  if (prop.type.toLowerCase() in scalarTypes) {
+  if (scalarTypes.includes(prop.type.toLowerCase() as SBScalarType['name'])) {
     return { name: prop.type.toLowerCase(), raw: prop.type, required: prop.required } as SBScalarType;
   }
 
@@ -11,11 +11,18 @@ export const inferSBType = (prop: JsonDocsProp): SBType => {
     return { name: 'function', raw: prop.type, required: prop.required };
   }
 
+  const enumValues = mapPropOptions(prop);
+  if (enumValues.length > 0) {
+    return { name: 'enum', value: enumValues, raw: prop.type, required: prop.required } as SBEnumType;
+  }
+
   return { name: 'other', value: prop.type, raw: prop.type, required: prop.required };
 };
 
 export const mapPropOptions = (prop: JsonDocsProp) =>
-  prop.values.filter((value) => ['string', 'number'].includes(value.type)).map(({ value }) => value);
+  prop.values
+    .filter((value) => ['string', 'number'].includes(value.type) && value.value !== undefined)
+    .map(({ value }) => value as string | number);
 
 export const inferControlType = (prop: JsonDocsProp): InputType['control'] => {
   switch (prop.type) {

--- a/tests/hmr.e2e.ts
+++ b/tests/hmr.e2e.ts
@@ -37,9 +37,20 @@ function makeUpdatedRender(token: string) {
   return `    return <div>Hello, ${token}! I'm {this.getText()}</div>;`;
 }
 
-async function readMyComponentText() {
+async function switchToPreviewIframe() {
   await browser.switchFrame(null);
-  await browser.switchFrame(() => Boolean(document.querySelector('my-component')));
+  const iframe = $('#storybook-preview-iframe');
+  await iframe.waitForExist({ timeout: 15000 });
+  await browser.waitUntil(async () => (await iframe.getAttribute('data-is-loaded')) === 'true', {
+    timeout: 30000,
+    interval: 250,
+    timeoutMsg: 'Storybook preview iframe never reached data-is-loaded=true',
+  });
+  await browser.switchFrame(iframe);
+}
+
+async function readMyComponentText() {
+  await switchToPreviewIframe();
   const el = await $('my-component');
   await el.waitForExist({ timeout: 15000 });
   // The lazy loader places <my-component> in the DOM immediately and hydrates
@@ -60,8 +71,7 @@ async function readMyComponentText() {
 }
 
 async function readHostDisplay() {
-  await browser.switchFrame(null);
-  await browser.switchFrame(() => Boolean(document.querySelector('my-component')));
+  await switchToPreviewIframe();
   const el = await $('my-component');
   await el.waitForExist({ timeout: 15000 });
   await browser.waitUntil(
@@ -101,17 +111,7 @@ describe(`StencilJS Storybook HMR (${PACKAGE})`, () => {
     }
 
     await browser.url(`/?path=/story/mycomponent--primary`);
-    const iframe = $('#storybook-preview-iframe');
-    await iframe.waitForExist({ timeout: 30000 });
-    // Storybook flips this to "true" only once the preview iframe has booted
-    // and a story is rendered. Without this we can switch into a still-empty
-    // iframe and time out waiting for <my-component>.
-    await browser.waitUntil(async () => (await iframe.getAttribute('data-is-loaded')) === 'true', {
-      timeout: 60000,
-      interval: 250,
-      timeoutMsg: 'Storybook preview iframe never reached data-is-loaded=true',
-    });
-    await browser.switchFrame(iframe);
+    await switchToPreviewIframe();
     await $('my-component').waitForExist({ timeout: 30000 });
     await browser.switchFrame(null);
   });


### PR DESCRIPTION
## Summary

Fixes three bugs in `packages/plugin/src/docs/infer-type.ts` and `custom-elements.ts` that caused Storybook URL `?args=` parameters to be silently dropped for Stencil components.

### Root causes

**1. `inferSBType`: `in` operator used on an array (`infer-type.ts`)**

`prop.type.toLowerCase() in scalarTypes` checks object _keys_, not array elements — always `false`. Every scalar prop (`string`, `number`, `boolean`) got type `{ name: 'other' }` instead of the correct scalar type, preventing Storybook from coercing URL arg values.

**2. `mapPropOptions`: plain-type props mapped to `[undefined]` (`infer-type.ts`)**

Stencil emits `values: [{ type: "string" }]` (no `value` key) for non-union props. The old filter kept these entries and `.map(({ value }) => value)` produced `[undefined]`. Since `[undefined].length > 0`, the original patch's `length > 0` guard didn't help — Storybook saw `options: [undefined]` and rejected any URL arg value.

**3. `inferSBType`: union/enum types returned `{ name: 'other' }` (`infer-type.ts`)**

Storybook's internal `mapArgsToTypes` passes each arg through a `map()` function that returns `INCOMPATIBLE` for `type.name === 'other'` (unless `type.value === 'ReactNode'`). This caused all radio/select union-typed props to be dropped when set via URL args. Fixed by returning `{ name: 'enum', value: [...] }` when enumerated values are present — matching the type Storybook expects for these controls.

**4. `tests/hmr.e2e.ts` — fix flaky iframe switching**

Replaced the inline `switchFrame` predicate (which raced against Storybook's load cycle) with a dedicated `switchToPreviewIframe()` helper that waits for `#storybook-preview-iframe` to exist and for `data-is-loaded=true` before switching frame context. Eliminates intermittent frame-not-found failures in CI.

### Changes

* `infer-type.ts` — `Array.includes()` replaces `in` for scalar type check
* `infer-type.ts` — `mapPropOptions` filters out entries with no `value` key
* `infer-type.ts` — `inferSBType` returns `SBEnumType` for union types with enumerated values
* `custom-elements.ts` — `options: undefined` instead of `options: []` for props with no enumerated values
* `.gitignore` — add `.pnpm-store/`
* `tests/hmr.e2e.ts` — replace racy `switchFrame` predicate with `switchToPreviewIframe()` helper

### Testing

Verified manually against the `example` package with all Stencil prop types (`string`, `number`, `boolean`, union/radio, union/select). URL args now apply correctly for all scalar and enum-typed props.

```
/iframe.html?id=mycomponent--primary&args=first:Gyles;radioTest:baz
```