### PR TITLE
fix: skip stencil preview reload during Vitest browser tests

### DIFF
--- a/packages/plugin/src/entry-preview.ts
+++ b/packages/plugin/src/entry-preview.ts
@@ -8,7 +8,7 @@ export { render, renderToCanvas } from './render';
 export const argTypesEnhancers: ArgTypesEnhancer[] = [enhanceArgTypes];
 
 // Reload the iframe when a Stencil component .tsx is rebuilt — see preset.ts.
-if (import.meta.hot) {
+if (import.meta.hot && !import.meta.env.VITEST) {
   import.meta.hot.on('stencil:reload', () => {
     location.reload();
   });

--- a/packages/plugin/src/preset.ts
+++ b/packages/plugin/src/preset.ts
@@ -21,6 +21,9 @@ const renderer = join(__dirname, 'entry-preview.js');
 
 const UNPLUGIN_STENCIL_NAME = '@stencil-community/unplugin-stencil';
 
+const isVitest =
+  process.env.VITEST === 'true' || process.env.VITEST === '1' || process.env.VITEST === '';
+
 export const core: StorybookConfig['core'] = {
   builder: join(getAbsolutePath('@storybook/builder-vite'), 'dist', 'index.js'),
   renderer,
@@ -54,7 +57,7 @@ export const viteFinal: StorybookConfig['viteFinal'] = async (defaultConfig, { c
           ignored: [join(__dirname, '**')],
         },
       },
-      plugins: [stencilPreviewReloadPlugin()],
+      plugins: isVitest ? [] : [stencilPreviewReloadPlugin()],
     });
   }
 

--- a/packages/plugin/src/typing.d.ts
+++ b/packages/plugin/src/typing.d.ts
@@ -5,4 +5,7 @@ interface ImportMeta {
   hot?: {
     on(event: string, cb: (...args: any[]) => void): void;
   };
+  env: {
+    VITEST?: boolean;
+  };
 }

--- a/tests/hmr.e2e.ts
+++ b/tests/hmr.e2e.ts
@@ -111,23 +111,8 @@ describe(`StencilJS Storybook HMR (${PACKAGE})`, () => {
     }
 
     await browser.url(`/?path=/story/mycomponent--primary`);
-    // Cold CI runs hit Vite dep-optimization reloads right after data-is-loaded;
-    // retry through iframe reloads until the story actually renders.
-    await browser.waitUntil(
-      async () => {
-        try {
-          await switchToPreviewIframe();
-          return await $('my-component').isExisting();
-        } catch {
-          return false;
-        }
-      },
-      {
-        timeout: 60000,
-        interval: 1000,
-        timeoutMsg: 'my-component never appeared in preview iframe',
-      },
-    );
+    await switchToPreviewIframe();
+    await $('my-component').waitForExist({ timeout: 30000 });
     await browser.switchFrame(null);
   });
 

--- a/tests/hmr.e2e.ts
+++ b/tests/hmr.e2e.ts
@@ -111,8 +111,23 @@ describe(`StencilJS Storybook HMR (${PACKAGE})`, () => {
     }
 
     await browser.url(`/?path=/story/mycomponent--primary`);
-    await switchToPreviewIframe();
-    await $('my-component').waitForExist({ timeout: 30000 });
+    // Cold CI runs hit Vite dep-optimization reloads right after data-is-loaded;
+    // retry through iframe reloads until the story actually renders.
+    await browser.waitUntil(
+      async () => {
+        try {
+          await switchToPreviewIframe();
+          return await $('my-component').isExisting();
+        } catch {
+          return false;
+        }
+      },
+      {
+        timeout: 60000,
+        interval: 1000,
+        timeoutMsg: 'my-component never appeared in preview iframe',
+      },
+    );
     await browser.switchFrame(null);
   });
 

--- a/tests/wdio.conf-lazy.ts
+++ b/tests/wdio.conf-lazy.ts
@@ -144,7 +144,7 @@ export const config: WebdriverIO.Config = {
   // See the full list at http://mochajs.org/
   mochaOpts: {
     ui: 'bdd',
-    timeout: 60000,
+    timeout: 120000,
   },
 
   //
@@ -216,8 +216,8 @@ export const config: WebdriverIO.Config = {
    * @param {Array.<String>} specs        List of spec file paths that are to be run
    * @param {object}         browser      instance of created browser/device session
    */
-  before: function () {
-    return browser.waitUntil(
+  before: async function () {
+    await browser.waitUntil(
       async () => {
         try {
           await browser.url('/');
@@ -232,6 +232,25 @@ export const config: WebdriverIO.Config = {
         timeoutMsg: 'Failed to start Storybook instance',
       },
     );
+
+    await browser.url('/?path=/story/mycomponent--primary');
+    await browser.waitUntil(
+      async () => {
+        try {
+          await browser.switchFrame(null);
+          await browser.switchFrame(() => Boolean(document.querySelector('my-component')));
+          return true;
+        } catch {
+          return false;
+        }
+      },
+      {
+        timeout: 120000,
+        interval: 2000,
+        timeoutMsg: 'Storybook preview never rendered my-component',
+      },
+    );
+    await browser.switchFrame(null);
   },
   /**
    * Runs before a WebdriverIO command gets executed.

--- a/tests/wdio.conf.ts
+++ b/tests/wdio.conf.ts
@@ -144,7 +144,7 @@ export const config: WebdriverIO.Config = {
   // See the full list at http://mochajs.org/
   mochaOpts: {
     ui: 'bdd',
-    timeout: 60000,
+    timeout: 120000,
   },
 
   //
@@ -216,8 +216,8 @@ export const config: WebdriverIO.Config = {
    * @param {Array.<String>} specs        List of spec file paths that are to be run
    * @param {object}         browser      instance of created browser/device session
    */
-  before: function () {
-    return browser.waitUntil(
+  before: async function () {
+    await browser.waitUntil(
       async () => {
         try {
           await browser.url('/');
@@ -232,6 +232,26 @@ export const config: WebdriverIO.Config = {
         timeoutMsg: 'Failed to start Storybook instance',
       },
     );
+
+    // Cold CI: the first spec must not race Vite dep-optimization for @stencil/core.
+    await browser.url('/?path=/story/mycomponent--primary');
+    await browser.waitUntil(
+      async () => {
+        try {
+          await browser.switchFrame(null);
+          await browser.switchFrame(() => Boolean(document.querySelector('my-component')));
+          return true;
+        } catch {
+          return false;
+        }
+      },
+      {
+        timeout: 120000,
+        interval: 2000,
+        timeoutMsg: 'Storybook preview never rendered my-component',
+      },
+    );
+    await browser.switchFrame(null);
   },
   /**
    * Runs before a WebdriverIO command gets executed.


### PR DESCRIPTION
## Summary

- `0.7.0` added `stencil:reload` → `location.reload()` for Storybook dev HMR when Stencil components are rebuilt
- Vitest browser mode runs each story file in an isolated iframe with Vite HMR active
- `stencilPreviewReloadPlugin`'s `transform` hook emits reload events during normal module graph builds, not only on file edits
- Parallel workers make this non-deterministic; Vitest aborts with "iframe was reloaded during a test"
- Fix: disable reload plugin + client listener when `VITEST` is set; dev Storybook behavior unchanged

## Test plan

- [ ] Vitest browser full parallel suite passes without iframe reload errors (MADS: `cd packages/ui-web && npm run test`)
- [ ] Storybook dev still full-reloads after component `.tsx` and `.css` edits
- [ ] Pinning to `0.6.1` vs this fix: no regression in dev reload behavior